### PR TITLE
Fix navigation properties to allow ExecutorTask creation

### DIFF
--- a/ClientsApp/Models/Entities/ExecutorTask.cs
+++ b/ClientsApp/Models/Entities/ExecutorTask.cs
@@ -7,10 +7,10 @@ namespace ClientsApp.Models.Entities
         public int ExecutorTaskId { get; set; }  // Первичный ключ для связи исполнителя и задачи
 
         public int ExecutorId { get; set; }  // Идентификатор исполнителя
-        public Executor Executor { get; set; }  // Навигационное свойство для исполнителя
+        public Executor? Executor { get; set; }  // Навигационное свойство для исполнителя
 
         public int ClientTaskId { get; set; }  // Идентификатор задачи
-        public ClientTask ClientTask { get; set; }  // Навигационное свойство для задачи
+        public ClientTask? ClientTask { get; set; }  // Навигационное свойство для задачи
 
         public decimal ActualTime { get; set; }  // Время, затраченное исполнителем
         public decimal AdjustedTime { get; set; }  // Скорректированное время


### PR DESCRIPTION
## Summary
- mark Executor and ClientTask navigation properties in `ExecutorTask` entity as nullable to prevent model state errors during creation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f2d4cf7e48328bd876c0d159eef81