### PR TITLE
Add client/task dropdowns for executor time logging

### DIFF
--- a/ClientsApp/Models/Entities/ExecutorTask.cs
+++ b/ClientsApp/Models/Entities/ExecutorTask.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ClientsApp.Models.Entities
@@ -6,11 +7,17 @@ namespace ClientsApp.Models.Entities
     {
         public int ExecutorTaskId { get; set; }  // Первичный ключ для связи исполнителя и задачи
 
-        public int ExecutorId { get; set; }  // Идентификатор исполнителя
-        public Executor? Executor { get; set; }  // Навигационное свойство для исполнителя
+        [Required(ErrorMessage = "Вкажіть виконавця")]
+        public int? ExecutorId { get; set; }  // Ідентифікатор виконавця
+        public Executor? Executor { get; set; }  // Навігаційне властивість виконавця
 
-        public int ClientTaskId { get; set; }  // Идентификатор задачи
-        public ClientTask? ClientTask { get; set; }  // Навигационное свойство для задачи
+        [NotMapped]
+        [Required(ErrorMessage = "Вкажіть клієнта")]
+        public int? ClientId { get; set; }  // Вибраний клієнт (для форми)
+
+        [Required(ErrorMessage = "Вкажіть завдання")]
+        public int? ClientTaskId { get; set; }  // Ідентифікатор завдання
+        public ClientTask? ClientTask { get; set; }  // Навігаційне властивість завдання
 
         public decimal ActualTime { get; set; }  // Время, затраченное исполнителем
         public decimal AdjustedTime { get; set; }  // Скорректированное время

--- a/ClientsApp/Views/ExecutorTask/Create.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Create.cshtml
@@ -8,30 +8,31 @@
 
 <form asp-action="Create" method="post">
     <div class="form-group">
-        <label for="ExecutorId">Виконавець</label>
-        <select id="ExecutorId" name="ExecutorId" class="form-control">
+        <label asp-for="ExecutorId"></label>
+        <select asp-for="ExecutorId" class="form-control" id="ExecutorId">
             <option value="">-- Виберіть виконавця --</option>
             @foreach (var ex in executors)
             {
-                <option value="@ex.ExecutorId"
-                        data-rate="@ex.HourlyRate"
-                        selected="@(ex.ExecutorId == Model?.ExecutorId)">
+                <option value="@ex.ExecutorId" data-rate="@ex.HourlyRate">
                     @ex.FullName
                 </option>
             }
         </select>
+        <span asp-validation-for="ExecutorId" class="text-danger"></span>
     </div>
     <div class="form-group">
-        <label for="ClientId">Клієнт</label>
-        <select id="ClientId" class="form-control">
+        <label asp-for="ClientId"></label>
+        <select asp-for="ClientId" class="form-control" asp-items="ViewBag.Clients" id="ClientId">
             <option value="">-- Виберіть клієнта --</option>
         </select>
+        <span asp-validation-for="ClientId" class="text-danger"></span>
     </div>
     <div class="form-group">
-        <label for="ClientTaskId">Завдання</label>
-        <select id="ClientTaskId" name="ClientTaskId" class="form-control">
+        <label asp-for="ClientTaskId"></label>
+        <select asp-for="ClientTaskId" class="form-control" asp-items="ViewBag.Tasks" id="ClientTaskId">
             <option value="">-- Виберіть завдання --</option>
         </select>
+        <span asp-validation-for="ClientTaskId" class="text-danger"></span>
     </div>
     <div class="form-group">
         <label asp-for="ActualTime"></label>
@@ -60,26 +61,19 @@
         const adjustedInput = document.getElementById('AdjustedTime');
         const costInput = document.getElementById('TaskCost');
 
-        executorSelect.addEventListener('change', async function(){
-            const executorId = this.value;
-            clientSelect.innerHTML = '<option value="">-- Виберіть клієнта --</option>';
+        executorSelect.addEventListener('change', function(){
             taskSelect.innerHTML = '<option value="">-- Виберіть завдання --</option>';
-            if(executorId){
-                const resp = await fetch(`/ExecutorTask/GetClientsByExecutor?executorId=${executorId}`);
-                const data = await resp.json();
-                data.forEach(c => {
-                    const opt = document.createElement('option');
-                    opt.value = c.clientId;
-                    opt.textContent = c.name;
-                    clientSelect.appendChild(opt);
-                });
-            }
+            loadTasks();
             updateCost();
         });
 
-        clientSelect.addEventListener('change', async function(){
+        clientSelect.addEventListener('change', function(){
+            loadTasks();
+        });
+
+        async function loadTasks(){
             const executorId = executorSelect.value;
-            const clientId = this.value;
+            const clientId = clientSelect.value;
             taskSelect.innerHTML = '<option value="">-- Виберіть завдання --</option>';
             if(executorId && clientId){
                 const resp = await fetch(`/ExecutorTask/GetTasksByExecutorClient?executorId=${executorId}&clientId=${clientId}`);
@@ -91,7 +85,7 @@
                     taskSelect.appendChild(opt);
                 });
             }
-        });
+        }
 
         function updateCost(){
             const rate = parseFloat(executorSelect.selectedOptions[0]?.getAttribute('data-rate')) || 0;
@@ -101,6 +95,7 @@
 
         adjustedInput.addEventListener('input', updateCost);
         executorSelect.addEventListener('change', updateCost);
+        updateCost();
     });
 </script>
 }


### PR DESCRIPTION
## Summary
- add validation and client selector to `ExecutorTask` model
- supply executors, clients and tasks to Create view and handle validation in controller
- render client and task dropdowns with dynamic task loading on Create page

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f31d94b908328b451a83e1793dcfb