### PR TITLE
Fix client binding on executor task edit form

### DIFF
--- a/ClientsApp/Views/ExecutorTask/Edit.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Edit.cshtml
@@ -27,7 +27,7 @@
     </div>
     <div class="form-group">
         <label for="ClientId">Клієнт</label>
-        <select id="ClientId" class="form-control">
+        <select id="ClientId" name="ClientId" class="form-control">
             <option value="">-- Виберіть клієнта --</option>
             @foreach (var cl in clients)
             {


### PR DESCRIPTION
## Summary
- Ensure client selection is posted in executor task edit form by adding missing `name` attribute.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f374d740083288ca77dd2a295a8f6