### PR TITLE
Implement payment summary with filtering

### DIFF
--- a/ClientsApp/BLL/Services/PaymentService.cs
+++ b/ClientsApp/BLL/Services/PaymentService.cs
@@ -18,12 +18,18 @@ namespace ClientsApp.BLL.Services
 
         public async Task<IEnumerable<Payment>> GetAllAsync()
         {
-            return await _context.Payments.ToListAsync();
+            return await _context.Payments
+                .Include(p => p.ClientTask)
+                    .ThenInclude(ct => ct.Client)
+                .ToListAsync();
         }
 
         public async Task<Payment> GetByIdAsync(int id)
         {
-            return await _context.Payments.FindAsync(id);
+            return await _context.Payments
+                .Include(p => p.ClientTask)
+                    .ThenInclude(ct => ct.Client)
+                .FirstOrDefaultAsync(p => p.PaymentId == id);
         }
 
         public async Task AddAsync(Payment payment)

--- a/ClientsApp/Controllers/PaymentController.cs
+++ b/ClientsApp/Controllers/PaymentController.cs
@@ -1,7 +1,10 @@
-﻿using ClientsApp.BLL.Interfaces;
-using ClientsApp.Models;
+using ClientsApp.BLL.Interfaces;
 using ClientsApp.Models.Entities;
+using ClientsApp.Models.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace ClientsApp.Controllers
@@ -9,24 +12,81 @@ namespace ClientsApp.Controllers
     public class PaymentController : Controller
     {
         private readonly IPaymentService _paymentService;
+        private readonly IClientService _clientService;
+        private readonly IClientTaskService _taskService;
 
-        public PaymentController(IPaymentService paymentService)
+        public PaymentController(IPaymentService paymentService,
+                                 IClientService clientService,
+                                 IClientTaskService taskService)
         {
             _paymentService = paymentService;
+            _clientService = clientService;
+            _taskService = taskService;
         }
 
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(int? clientId, bool? isPaid)
         {
+            var tasks = await _taskService.GetAllAsync();
             var payments = await _paymentService.GetAllAsync();
-            return View(payments);
+
+            var summaries = tasks.Select(t =>
+            {
+                var cost = t.ExecutorTasks.Sum(et => et.AdjustedTime * (et.Executor?.HourlyRate ?? 0));
+                var received = payments.Where(p => p.ClientTaskId == t.ClientTaskId).Sum(p => p.Amount);
+                return new PaymentSummaryViewModel
+                {
+                    ClientTaskId = t.ClientTaskId,
+                    ClientId = t.ClientId ?? 0,
+                    ClientName = t.Client?.Name ?? string.Empty,
+                    TaskTitle = t.TaskTitle,
+                    ServiceCost = cost,
+                    AmountReceived = received,
+                    BalanceDue = cost - received
+                };
+            });
+
+            if (clientId.HasValue)
+                summaries = summaries.Where(s => s.ClientId == clientId.Value);
+
+            if (isPaid.HasValue)
+                summaries = isPaid.Value
+                    ? summaries.Where(s => s.BalanceDue <= 0)
+                    : summaries.Where(s => s.BalanceDue > 0);
+
+            var clients = await _clientService.GetAllAsync();
+            var model = new PaymentIndexViewModel
+            {
+                Payments = summaries.ToList(),
+                Clients = clients.Select(c => new SelectListItem
+                {
+                    Value = c.ClientId.ToString(),
+                    Text = c.Name
+                }).ToList(),
+                SelectedClientId = clientId,
+                IsPaid = isPaid
+            };
+
+            return View(model);
         }
 
-        public IActionResult Create() => View();
+        public async Task<IActionResult> Create()
+        {
+            await PopulateTasks();
+            return View();
+        }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(Payment payment)
         {
-            if (!ModelState.IsValid) return View(payment);
+            if (!ModelState.IsValid)
+            {
+                await PopulateTasks();
+                return View(payment);
+            }
+
+            payment.PaymentDate = DateTime.Now;
+            payment.BalanceDue = await CalculateBalanceDue(payment.ClientTaskId, payment.Amount, null);
             await _paymentService.AddAsync(payment);
             return RedirectToAction(nameof(Index));
         }
@@ -35,23 +95,58 @@ namespace ClientsApp.Controllers
         {
             var payment = await _paymentService.GetByIdAsync(id);
             if (payment == null) return NotFound();
+            await PopulateTasks();
             return View(payment);
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(Payment payment)
         {
-            if (!ModelState.IsValid) return View(payment);
+            if (!ModelState.IsValid)
+            {
+                await PopulateTasks();
+                return View(payment);
+            }
+
+            payment.BalanceDue = await CalculateBalanceDue(payment.ClientTaskId, payment.Amount, payment.PaymentId);
             await _paymentService.UpdateAsync(payment);
             return RedirectToAction(nameof(Index));
         }
 
+        [HttpGet]
         public async Task<IActionResult> Delete(int id)
         {
             var payment = await _paymentService.GetByIdAsync(id);
             if (payment == null) return NotFound();
+            return View(payment);
+        }
+
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
             await _paymentService.DeleteAsync(id);
             return RedirectToAction(nameof(Index));
+        }
+
+        private async Task PopulateTasks()
+        {
+            var tasks = await _taskService.GetAllAsync();
+            ViewBag.Tasks = tasks.Select(t => new SelectListItem
+            {
+                Value = t.ClientTaskId.ToString(),
+                Text = $"{t.Client?.Name} - {t.TaskTitle}"
+            }).ToList();
+        }
+
+        private async Task<decimal> CalculateBalanceDue(int taskId, decimal newAmount, int? currentPaymentId)
+        {
+            var task = await _taskService.GetByIdAsync(taskId);
+            var cost = task.ExecutorTasks.Sum(et => et.AdjustedTime * (et.Executor?.HourlyRate ?? 0));
+            var payments = await _paymentService.GetAllAsync();
+            var paid = payments.Where(p => p.ClientTaskId == taskId && p.PaymentId != currentPaymentId).Sum(p => p.Amount);
+            return cost - (paid + newAmount);
         }
     }
 }

--- a/ClientsApp/Models/Entities/Payment.cs
+++ b/ClientsApp/Models/Entities/Payment.cs
@@ -1,14 +1,21 @@
-﻿namespace ClientsApp.Models.Entities
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ClientsApp.Models.Entities
 {
     public class Payment
     {
-        public int PaymentId { get; set; }  // Первичный ключ для платежа
+        public int PaymentId { get; set; }
 
-        public int ClientTaskId { get; set; }  // Идентификатор задачи, за которую сделан платеж
-        public ClientTask ClientTask { get; set; }  // Навигационное свойство для задачи
+        [Required]
+        public int ClientTaskId { get; set; }
+        public ClientTask ClientTask { get; set; }
 
-        public decimal Amount { get; set; }  // Сумма платежа
-        public DateTime PaymentDate { get; set; }  // Дата платежа
-        public decimal BalanceDue { get; set; }  // Потенциальная задолженность по задаче
+        [Required]
+        [Range(0, double.MaxValue)]
+        public decimal Amount { get; set; }
+
+        public DateTime PaymentDate { get; set; }
+        public decimal BalanceDue { get; set; }
     }
 }

--- a/ClientsApp/Models/ViewModels/PaymentIndexViewModel.cs
+++ b/ClientsApp/Models/ViewModels/PaymentIndexViewModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace ClientsApp.Models.ViewModels
+{
+    public class PaymentIndexViewModel
+    {
+        public IEnumerable<PaymentSummaryViewModel> Payments { get; set; } = new List<PaymentSummaryViewModel>();
+        public List<SelectListItem> Clients { get; set; } = new List<SelectListItem>();
+        public int? SelectedClientId { get; set; }
+        public bool? IsPaid { get; set; }
+    }
+}

--- a/ClientsApp/Models/ViewModels/PaymentSummaryViewModel.cs
+++ b/ClientsApp/Models/ViewModels/PaymentSummaryViewModel.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ClientsApp.Models.ViewModels
+{
+    public class PaymentSummaryViewModel
+    {
+        public int ClientTaskId { get; set; }
+        public int ClientId { get; set; }
+        public string ClientName { get; set; }
+        public string TaskTitle { get; set; }
+        public decimal ServiceCost { get; set; }
+        public decimal AmountReceived { get; set; }
+        public decimal BalanceDue { get; set; }
+    }
+}

--- a/ClientsApp/Views/Payment/Create.cshtml
+++ b/ClientsApp/Views/Payment/Create.cshtml
@@ -1,0 +1,23 @@
+@model ClientsApp.Models.Entities.Payment
+@{
+    ViewData["Title"] = "Додати платіж";
+}
+
+<h2>Додати платіж</h2>
+
+<form asp-action="Create" method="post">
+    <div class="form-group">
+        <label asp-for="ClientTaskId"></label>
+        <select asp-for="ClientTaskId" class="form-control" asp-items="ViewBag.Tasks">
+            <option value="">-- Виберіть завдання --</option>
+        </select>
+        <span asp-validation-for="ClientTaskId" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Amount"></label>
+        <input asp-for="Amount" class="form-control" />
+        <span asp-validation-for="Amount" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-success">Зберегти</button>
+    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+</form>

--- a/ClientsApp/Views/Payment/Delete.cshtml
+++ b/ClientsApp/Views/Payment/Delete.cshtml
@@ -1,0 +1,24 @@
+@model ClientsApp.Models.Entities.Payment
+@{
+    ViewData["Title"] = "Видалити платіж";
+}
+
+<h2>Видалити платіж</h2>
+
+<div>
+    <h4>Ви впевнені, що хочете видалити цей платіж?</h4>
+    <dl class="row">
+        <dt class="col-sm-2">Клієнт</dt>
+        <dd class="col-sm-10">@Model.ClientTask?.Client?.Name</dd>
+        <dt class="col-sm-2">Завдання</dt>
+        <dd class="col-sm-10">@Model.ClientTask?.TaskTitle</dd>
+        <dt class="col-sm-2">Сума</dt>
+        <dd class="col-sm-10">@Model.Amount.ToString("F2")</dd>
+    </dl>
+</div>
+
+<form asp-action="Delete" method="post">
+    <input type="hidden" asp-for="PaymentId" />
+    <button type="submit" class="btn btn-danger">Видалити</button>
+    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+</form>

--- a/ClientsApp/Views/Payment/Edit.cshtml
+++ b/ClientsApp/Views/Payment/Edit.cshtml
@@ -1,0 +1,27 @@
+@model ClientsApp.Models.Entities.Payment
+@{
+    ViewData["Title"] = "Редагувати платіж";
+}
+
+<h2>Редагувати платіж</h2>
+
+<form asp-action="Edit" method="post">
+    <input type="hidden" asp-for="PaymentId" />
+    <div class="form-group">
+        <label asp-for="ClientTaskId"></label>
+        <select asp-for="ClientTaskId" class="form-control" asp-items="ViewBag.Tasks"></select>
+        <span asp-validation-for="ClientTaskId" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Amount"></label>
+        <input asp-for="Amount" class="form-control" />
+        <span asp-validation-for="Amount" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="PaymentDate"></label>
+        <input asp-for="PaymentDate" class="form-control" type="date" />
+        <span asp-validation-for="PaymentDate" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Зберегти</button>
+    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+</form>

--- a/ClientsApp/Views/Payment/Index.cshtml
+++ b/ClientsApp/Views/Payment/Index.cshtml
@@ -1,0 +1,48 @@
+@model ClientsApp.Models.ViewModels.PaymentIndexViewModel
+@{
+    ViewData["Title"] = "Платежі";
+}
+
+<h2>Платежі</h2>
+
+<form method="get" class="form-inline mb-3">
+    <div class="form-group mr-2">
+        <select asp-for="SelectedClientId" asp-items="Model.Clients" class="form-control">
+            <option value="">Всі клієнти</option>
+        </select>
+    </div>
+    <div class="form-group mr-2">
+        <select asp-for="IsPaid" class="form-control">
+            <option value="">Всі</option>
+            <option value="true">Оплачені</option>
+            <option value="false">Неоплачені</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Фільтрувати</button>
+</form>
+
+<a asp-action="Create" class="btn btn-success mb-2">Додати платіж</a>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Клієнт</th>
+            <th>Завдання</th>
+            <th>Вартість послуг</th>
+            <th>Оплачено</th>
+            <th>Заборгованість</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var p in Model.Payments)
+    {
+        <tr>
+            <td>@p.ClientName</td>
+            <td>@p.TaskTitle</td>
+            <td>@p.ServiceCost.ToString("F2")</td>
+            <td>@p.AmountReceived.ToString("F2")</td>
+            <td>@p.BalanceDue.ToString("F2")</td>
+        </tr>
+    }
+    </tbody>
+</table>


### PR DESCRIPTION
## Summary
- add payment summary view models and views
- compute task cost and payment balance with client filtering
- annotate payment entity and expand payment service

## Testing
- `dotnet build -c Release` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689f3c4434648328b52826ee9612a814