### PR TITLE
Fix ClientTask filtering and executor display

### DIFF
--- a/ClientsApp/BLL/Services/ClientTaskService.cs
+++ b/ClientsApp/BLL/Services/ClientTaskService.cs
@@ -43,7 +43,20 @@ namespace ClientsApp.BLL
 
         public async Task UpdateAsync(ClientTask task)
         {
-            _context.ClientTasks.Update(task);
+            var existingTask = await _context.ClientTasks
+                .Include(ct => ct.ExecutorTasks)
+                .FirstOrDefaultAsync(ct => ct.ClientTaskId == task.ClientTaskId);
+
+            if (existingTask == null) return;
+
+            _context.Entry(existingTask).CurrentValues.SetValues(task);
+
+            existingTask.ExecutorTasks.Clear();
+            foreach (var et in task.ExecutorTasks)
+            {
+                existingTask.ExecutorTasks.Add(new ExecutorTask { ExecutorId = et.ExecutorId });
+            }
+
             await _context.SaveChangesAsync();
         }
 

--- a/ClientsApp/Views/ClientTask/Create.cshtml
+++ b/ClientsApp/Views/ClientTask/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model ClientsApp.Models.Entities.ClientTask
+@model ClientsApp.Models.Entities.ClientTask
 
 @{
     ViewData["Title"] = "Додати завдання";
@@ -31,34 +31,8 @@
         <input asp-for="EndDate" type="date" class="form-control" />
         <span asp-validation-for="EndDate" class="text-danger"></span>
     </div>
-    <!-- Статус завдання -->
-    <div class="form-group">
-        <label asp-for="TaskStatus"></label>
-        <select asp-for="TaskStatus" class="form-control" asp-items="ViewBag.Statuses">
-            <option value="">-- Виберіть статус --</option>
-        </select>
-        <span asp-validation-for="TaskStatus" class="text-danger"></span>
-    </div>
-    <!-- Клієнт -->
-    @* <div class="form-group">
-        <label asp-for="ClientId"></label>
-        <select asp-for="ClientId" class="form-control" asp-items="ViewBag.Clients">
-            <option value="">-- Виберіть клієнта --</option>
-        </select>
-        <span asp-validation-for="ClientId" class="text-danger"></span>
-    </div> *@
 
-    <!-- Виконавець -->
     <div class="form-group">
-        <label asp-for="ExecutorId"></label>
-        <select asp-for="ExecutorId" class="form-control" asp-items="ViewBag.Executors">
-            <option value="">-- Виберіть виконавця --</option>
-        </select>
-        <span asp-validation-for="ExecutorId" class="text-danger"></span>
-    </div>
-    
-    <div class="form-group">
-        @* <label>Клієнт</label> *@
         <label asp-for="ClientId"></label>
         <select asp-for="ClientId" class="form-control" asp-items="ViewBag.Clients">
             <option value="">Виберіть клієнта</option>
@@ -66,8 +40,11 @@
         <span asp-validation-for="ClientId" class="text-danger"></span>
     </div>
 
-    
-    <!-- Статус завдання -->
+    <div class="form-group">
+        <label>Виконавці</label>
+        <select name="selectedExecutors" class="form-control" multiple asp-items="ViewBag.Executors"></select>
+    </div>
+
     <div class="form-group">
         <label asp-for="TaskStatus"></label>
         <select asp-for="TaskStatus" class="form-control" asp-items="ViewBag.Statuses">

--- a/ClientsApp/Views/ClientTask/Edit.cshtml
+++ b/ClientsApp/Views/ClientTask/Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@model ClientsApp.Models.Entities.ClientTask
+@model ClientsApp.Models.Entities.ClientTask
 
 @{
     ViewData["Title"] = "Редагувати завдання";
@@ -42,10 +42,8 @@
     </div>
 
     <div class="form-group">
-        <label>Виконавець</label>
-        <select asp-for="ExecutorId" class="form-control" asp-items="ViewBag.Executors">
-            <option value="">Виберіть виконавця</option>
-        </select>
+        <label>Виконавці</label>
+        <select name="selectedExecutors" class="form-control" multiple asp-items="ViewBag.Executors"></select>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
## Summary
- Fix ClientTask filtering by binding form fields to controller parameters
- Correctly manage task executors with multi-select creation and editing
- Update service to persist executor assignments properly

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f4ad2bf308328800a0fb887465013