### PR TITLE
Handle nullable executor IDs in task editor

### DIFF
--- a/ClientsApp/Controllers/ClientTaskController.cs
+++ b/ClientsApp/Controllers/ClientTaskController.cs
@@ -111,7 +111,10 @@ namespace ClientsApp.Controllers
                 EndDate = task.EndDate,
                 ClientId = task.ClientId,
                 TaskStatus = task.TaskStatus,
-                SelectedExecutors = task.ExecutorTasks.Select(et => et.ExecutorId).ToList(),
+                SelectedExecutors = task.ExecutorTasks
+                    .Where(et => et.ExecutorId.HasValue)
+                    .Select(et => et.ExecutorId!.Value)
+                    .ToList(),
                 Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", task.ClientId),
                 Executors = new MultiSelectList(await _executorService.GetAllAsync(), "ExecutorId", "FullName", task.ExecutorTasks.Select(et => et.ExecutorId)),
                 Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), task.TaskStatus)


### PR DESCRIPTION
## Summary
- Avoid converting nullable executor IDs directly to a non-nullable list in the task editor

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f5449f1548328963764292c82f2f5