### PR TITLE
Fix validation for ClientTask edit form

### DIFF
--- a/ClientsApp/Controllers/ClientTaskController.cs
+++ b/ClientsApp/Controllers/ClientTaskController.cs
@@ -129,10 +129,10 @@ namespace ClientsApp.Controllers
         {
             if (!ModelState.IsValid)
             {
-                model.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", model.ClientId);
-                model.Executors = new MultiSelectList(await _executorService.GetAllAsync(), "ExecutorId", "FullName", model.SelectedExecutors);
-                model.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), model.TaskStatus);
-                return View(model);
+                var errors = ModelState.Values
+                    .SelectMany(v => v.Errors)
+                    .Select(e => e.ErrorMessage);
+                return Content("ModelState invalid: " + string.Join(", ", errors));
             }
 
             var task = new ClientTask

--- a/ClientsApp/Models/ViewModels/ClientTaskEditViewModel.cs
+++ b/ClientsApp/Models/ViewModels/ClientTaskEditViewModel.cs
@@ -32,8 +32,8 @@ namespace ClientsApp.Models.ViewModels
 
         public List<int> SelectedExecutors { get; set; } = new();
 
-        public SelectList Clients { get; set; }
-        public MultiSelectList Executors { get; set; }
-        public SelectList Statuses { get; set; }
+        public SelectList? Clients { get; set; }
+        public MultiSelectList? Executors { get; set; }
+        public SelectList? Statuses { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- make ClientTaskEditViewModel dropdown lists nullable to avoid spurious ModelState errors
- add debug output of ModelState errors in ClientTaskController Edit action

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f5796d89483288dea6d488b029a8d