### PR TITLE
Fix executor task edit form population

### DIFF
--- a/ClientsApp/BLL/Services/ExecutorTaskService.cs
+++ b/ClientsApp/BLL/Services/ExecutorTaskService.cs
@@ -59,18 +59,21 @@ namespace ClientsApp.BLL.Services
 
         public async Task<IEnumerable<Client>> GetClientsByExecutorAsync(int executorId)
         {
-            return await _context.ClientTasks
-                .Where(ct => ct.ExecutorId == executorId)
-                .Include(ct => ct.Client)
-                .Select(ct => ct.Client!)
+            return await _context.ExecutorTasks
+                .Where(et => et.ExecutorId == executorId)
+                .Include(et => et.ClientTask)
+                    .ThenInclude(ct => ct.Client)
+                .Select(et => et.ClientTask!.Client!)
                 .Distinct()
                 .ToListAsync();
         }
 
         public async Task<IEnumerable<ClientTask>> GetTasksByExecutorAndClientAsync(int executorId, int clientId)
         {
-            return await _context.ClientTasks
-                .Where(ct => ct.ExecutorId == executorId && ct.ClientId == clientId)
+            return await _context.ExecutorTasks
+                .Where(et => et.ExecutorId == executorId && et.ClientTask!.ClientId == clientId)
+                .Select(et => et.ClientTask!)
+                .Distinct()
                 .ToListAsync();
         }
     }

--- a/ClientsApp/Controllers/ExecutorTaskController.cs
+++ b/ClientsApp/Controllers/ExecutorTaskController.cs
@@ -65,6 +65,7 @@ namespace ClientsApp.Controllers
             ViewBag.Executors = await _executorService.GetAllAsync();
             ViewBag.Clients = await _executorTaskService.GetClientsByExecutorAsync(executorTask.ExecutorId ?? 0);
             var clientId = executorTask.ClientTask?.ClientId ?? 0;
+            executorTask.ClientId = clientId;
             ViewBag.Tasks = await _executorTaskService.GetTasksByExecutorAndClientAsync(executorTask.ExecutorId ?? 0, clientId);
             ViewBag.CurrentClientId = clientId;
             return View(executorTask);
@@ -81,7 +82,7 @@ namespace ClientsApp.Controllers
             }
             ViewBag.Executors = await _executorService.GetAllAsync();
             ViewBag.Clients = await _executorTaskService.GetClientsByExecutorAsync(executorTask.ExecutorId ?? 0);
-            var clientId = (await _executorTaskService.GetByIdAsync(executorTask.ExecutorTaskId))?.ClientTask?.ClientId ?? 0;
+            var clientId = executorTask.ClientId ?? (await _executorTaskService.GetByIdAsync(executorTask.ExecutorTaskId))?.ClientTask?.ClientId ?? 0;
             ViewBag.Tasks = await _executorTaskService.GetTasksByExecutorAndClientAsync(executorTask.ExecutorId ?? 0, clientId);
             ViewBag.CurrentClientId = clientId;
             return View(executorTask);


### PR DESCRIPTION
## Summary
- Load clients and tasks for a selected executor using ExecutorTasks to keep edit form populated
- Preserve selected client when editing and reload task list based on user choice

## Testing
- ⚠️ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f597a325c83289648f4a340dc9323