### PR TITLE
Add filtering options for ExecutorTask list

### DIFF
--- a/ClientsApp/BLL/Interfaces/IExecutorTaskService.cs
+++ b/ClientsApp/BLL/Interfaces/IExecutorTaskService.cs
@@ -6,7 +6,7 @@ namespace ClientsApp.BLL.Interfaces
 {
     public interface IExecutorTaskService
     {
-        Task<IEnumerable<ExecutorTask>> GetAllAsync();
+        Task<IEnumerable<ExecutorTask>> GetAllAsync(int? executorId = null, int? clientId = null, int? taskId = null);
         Task<ExecutorTask> GetByIdAsync(int id);
         Task AddAsync(ExecutorTask executorTask);
         Task UpdateAsync(ExecutorTask executorTask);

--- a/ClientsApp/BLL/Services/ExecutorTaskService.cs
+++ b/ClientsApp/BLL/Services/ExecutorTaskService.cs
@@ -17,13 +17,30 @@ namespace ClientsApp.BLL.Services
             _context = context;
         }
 
-        public async Task<IEnumerable<ExecutorTask>> GetAllAsync()
+        public async Task<IEnumerable<ExecutorTask>> GetAllAsync(int? executorId = null, int? clientId = null, int? taskId = null)
         {
-            return await _context.ExecutorTasks
+            var query = _context.ExecutorTasks
                 .Include(et => et.Executor)
                 .Include(et => et.ClientTask)
                     .ThenInclude(ct => ct.Client)
-                .ToListAsync();
+                .AsQueryable();
+
+            if (executorId.HasValue)
+            {
+                query = query.Where(et => et.ExecutorId == executorId.Value);
+            }
+
+            if (clientId.HasValue)
+            {
+                query = query.Where(et => et.ClientTask!.ClientId == clientId.Value);
+            }
+
+            if (taskId.HasValue)
+            {
+                query = query.Where(et => et.ClientTaskId == taskId.Value);
+            }
+
+            return await query.ToListAsync();
         }
 
         public async Task<ExecutorTask> GetByIdAsync(int id)

--- a/ClientsApp/Controllers/ExecutorTaskController.cs
+++ b/ClientsApp/Controllers/ExecutorTaskController.cs
@@ -26,9 +26,13 @@ namespace ClientsApp.Controllers
             _clientTaskService = clientTaskService;
         }
 
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(int? executorId, int? clientId, int? taskId)
         {
-            var items = await _executorTaskService.GetAllAsync();
+            ViewBag.Executors = new SelectList(await _executorService.GetAllAsync(), "ExecutorId", "FullName", executorId);
+            ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", clientId);
+            ViewBag.Tasks = new SelectList(await _clientTaskService.GetAllAsync(), "ClientTaskId", "TaskTitle", taskId);
+
+            var items = await _executorTaskService.GetAllAsync(executorId, clientId, taskId);
             return View(items);
         }
 

--- a/ClientsApp/Views/ExecutorTask/Index.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Index.cshtml
@@ -4,6 +4,39 @@
 }
 
 <h2>Завдання виконавців</h2>
+<form method="get" class="row g-3 mb-3">
+    <div class="col-md-3">
+        <select name="executorId" class="form-select">
+            <option value="">Всі виконавці</option>
+            @foreach (var e in (SelectList)ViewBag.Executors)
+            {
+                <option value="@e.Value" @(e.Selected ? "selected" : null)>@e.Text</option>
+            }
+        </select>
+    </div>
+    <div class="col-md-3">
+        <select name="clientId" class="form-select">
+            <option value="">Всі клієнти</option>
+            @foreach (var c in (SelectList)ViewBag.Clients)
+            {
+                <option value="@c.Value" @(c.Selected ? "selected" : null)>@c.Text</option>
+            }
+        </select>
+    </div>
+    <div class="col-md-3">
+        <select name="taskId" class="form-select">
+            <option value="">Всі завдання</option>
+            @foreach (var t in (SelectList)ViewBag.Tasks)
+            {
+                <option value="@t.Value" @(t.Selected ? "selected" : null)>@t.Text</option>
+            }
+        </select>
+    </div>
+    <div class="col-md-3 d-flex align-items-end">
+        <button type="submit" class="btn btn-primary me-2">Фільтрувати</button>
+        <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути усі фільтри</a>
+    </div>
+</form>
 
 <a asp-action="Create" class="btn btn-success mb-2">Додати запис</a>
 
@@ -37,3 +70,12 @@
     }
     </tbody>
 </table>
+
+@section Scripts {
+    <script>
+        const nav = window.performance && window.performance.getEntriesByType('navigation')[0];
+        if (nav && nav.type === 'reload' && window.location.search) {
+            window.location.replace(window.location.pathname);
+        }
+    </script>
+}


### PR DESCRIPTION
## Summary
- enable filtering ExecutorTask records by executor, client, and task
- add Reset all filters button and auto reset on page reload

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5c1e1a8c83289776c0cac18e7f38