### PR TITLE
Add global filter reset buttons and reset-on-reload behavior

### DIFF
--- a/ClientsApp/Views/ClientTask/Index.cshtml
+++ b/ClientsApp/Views/ClientTask/Index.cshtml
@@ -31,6 +31,7 @@
     </div>
 
     <button type="submit" class="btn btn-primary">Фільтрувати</button>
+    <a asp-action="Index" class="btn btn-secondary ms-2" id="resetFilters">Скинути усі фільтри</a>
 </form>
 
 <table class="table table-striped">
@@ -79,3 +80,12 @@
         }
     </tbody>
 </table>
+
+@section Scripts {
+    <script>
+        const nav = window.performance && window.performance.getEntriesByType('navigation')[0];
+        if (nav && nav.type === 'reload' && window.location.search) {
+            window.location.replace(window.location.pathname);
+        }
+    </script>
+}

--- a/ClientsApp/Views/Payment/Index.cshtml
+++ b/ClientsApp/Views/Payment/Index.cshtml
@@ -19,6 +19,7 @@
         </select>
     </div>
     <button type="submit" class="btn btn-primary">Фільтрувати</button>
+    <a asp-action="Index" class="btn btn-secondary ms-2" id="resetFilters">Скинути усі фільтри</a>
 </form>
 
 <a asp-action="Create" class="btn btn-success mb-2">Додати платіж</a>
@@ -46,3 +47,12 @@
     }
     </tbody>
 </table>
+
+@section Scripts {
+    <script>
+        const nav = window.performance && window.performance.getEntriesByType('navigation')[0];
+        if (nav && nav.type === 'reload' && window.location.search) {
+            window.location.replace(window.location.pathname);
+        }
+    </script>
+}


### PR DESCRIPTION
## Summary
- add "Скинути усі фільтри" buttons to Payment and ClientTask pages
- ensure filters clear on page reload with navigation check

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f60a8fe048328a2f1f051672c4a6d