### PR TITLE
Reset client search parameters on refresh

### DIFF
--- a/ClientsApp/Views/Client/Index.cshtml
+++ b/ClientsApp/Views/Client/Index.cshtml
@@ -43,3 +43,12 @@
         }
     </tbody>
 </table>
+
+@section Scripts {
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        if (params.has('searchString')) {
+            window.history.replaceState({}, '', window.location.pathname);
+        }
+    </script>
+}


### PR DESCRIPTION
## Summary
- Remove search query from URL after client search results are displayed, so refreshing shows full list

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository unsigned / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f654e0a0883288811226cf2eb61b9