### PR TITLE
Unify styles and redesign home page

### DIFF
--- a/ClientsApp/Views/Client/Create.cshtml
+++ b/ClientsApp/Views/Client/Create.cshtml
@@ -32,7 +32,7 @@
         <span asp-validation-for="Phone" class="text-danger"></span>
     </div>
 
-    <button type="submit" class="btn btn-primary">Зберегти</button>
+    <button type="submit" class="btn btn-success">Зберегти</button>
 </form>
 
 @section Scripts {

--- a/ClientsApp/Views/Client/Details.cshtml
+++ b/ClientsApp/Views/Client/Details.cshtml
@@ -21,6 +21,6 @@
 </div>
 
 <p>
-    <a asp-action="Edit" asp-route-id="@Model.ClientId" class="btn btn-warning">Редагувати</a>
+    <a asp-action="Edit" asp-route-id="@Model.ClientId" class="btn btn-primary">Редагувати</a>
     <a asp-action="Index" class="btn btn-secondary">Назад</a>
 </p>

--- a/ClientsApp/Views/Client/Edit.cshtml
+++ b/ClientsApp/Views/Client/Edit.cshtml
@@ -37,7 +37,7 @@
         <span asp-validation-for="Phone" class="text-danger"></span>
     </div>
 
-    <button type="submit" class="btn btn-primary">Зберегти</button>
+    <button type="submit" class="btn btn-success">Зберегти</button>
     <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
 </form>
 

--- a/ClientsApp/Views/Client/Index.cshtml
+++ b/ClientsApp/Views/Client/Index.cshtml
@@ -10,13 +10,16 @@
 <p>Ви можете здійснювати пошук клієнтів за їх назвою, у тому числі частковою. </p>
 
 <p>
-    <a asp-action="Create" class="btn btn-primary">Додати клієнта</a>
+    <a asp-action="Create" class="btn btn-success mb-2">Додати клієнта</a>
 </p>
 
-<form method="get" class="mb-3">
-    <div class="input-group">
+<form method="get" class="row g-3 mb-3">
+    <div class="col-md-4">
         <input type="text" name="searchString" value="@ViewData["SearchString"]" class="form-control" placeholder="Пошук за ім'ям" minlength="3" />
-        <button type="submit" class="btn btn-secondary">Пошук</button>
+    </div>
+    <div class="col-md-4 d-flex align-items-end">
+        <button type="submit" class="btn btn-primary me-2">Пошук</button>
+        <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути</a>
     </div>
 </form>
 
@@ -39,8 +42,8 @@
                 <td>@client.Email</td>
                 <td>@client.Phone</td>
                 <td>
-                    <a asp-action="Edit" asp-route-id="@client.ClientId" class="btn btn-sm btn-warning">Редагувати</a>
-                    <a asp-action="Delete" asp-route-id="@client.ClientId" class="btn btn-sm btn-danger">Видалити</a>
+                    <a asp-action="Edit" asp-route-id="@client.ClientId" class="btn btn-primary btn-sm">Редагувати</a>
+                    <a asp-action="Delete" asp-route-id="@client.ClientId" class="btn btn-danger btn-sm">Видалити</a>
                 </td>
             </tr>
         }
@@ -49,9 +52,9 @@
 
 @section Scripts {
     <script>
-        const params = new URLSearchParams(window.location.search);
-        if (params.has('searchString')) {
-            window.history.replaceState({}, '', window.location.pathname);
+        const nav = window.performance && window.performance.getEntriesByType('navigation')[0];
+        if (nav && nav.type === 'reload' && window.location.search) {
+            window.location.replace(window.location.pathname);
         }
     </script>
 }

--- a/ClientsApp/Views/ClientTask/Index.cshtml
+++ b/ClientsApp/Views/ClientTask/Index.cshtml
@@ -9,32 +9,28 @@
 <p>На цій сторінці Завдання Ви можете отримати усю інформацію по усіх завданнях фірми,  а також додавати інформацію, редагувати та видаляти її. </p>
 <p>Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів. </p>
 
- <a asp-action="Create" class="btn btn-success">Додати завдання</a>
+ <a asp-action="Create" class="btn btn-success mb-2">Додати завдання</a>
 
-<form asp-action="Index" method="get" class="form-inline mb-3">
-    <div class="form-group mr-2">
-        <label asp-for="SelectedClientId" class="mr-1">Клієнт:</label>
-        <select asp-for="SelectedClientId" class="form-control" asp-items="Model.Clients">
+<form asp-action="Index" method="get" class="row g-3 mb-3">
+    <div class="col-md-3">
+        <select asp-for="SelectedClientId" class="form-select" asp-items="Model.Clients">
             <option value="">Всі</option>
         </select>
     </div>
-
-    <div class="form-group mr-2">
-        <label asp-for="SelectedExecutorId" class="mr-1">Виконавець:</label>
-        <select asp-for="SelectedExecutorId" class="form-control" asp-items="Model.Executors">
+    <div class="col-md-3">
+        <select asp-for="SelectedExecutorId" class="form-select" asp-items="Model.Executors">
             <option value="">Всі</option>
         </select>
     </div>
-
-    <div class="form-group mr-2">
-        <label asp-for="SelectedStatus" class="mr-1">Статус:</label>
-        <select asp-for="SelectedStatus" class="form-control" asp-items="Model.Statuses">
+    <div class="col-md-3">
+        <select asp-for="SelectedStatus" class="form-select" asp-items="Model.Statuses">
             <option value="">Всі</option>
         </select>
     </div>
-
-    <button type="submit" class="btn btn-primary">Фільтрувати</button>
-    <a asp-action="Index" class="btn btn-secondary ms-2" id="resetFilters">Скинути усі фільтри</a>
+    <div class="col-md-3 d-flex align-items-end">
+        <button type="submit" class="btn btn-primary me-2">Фільтрувати</button>
+        <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути усі фільтри</a>
+    </div>
 </form>
 
 <table class="table table-striped">

--- a/ClientsApp/Views/Executor/Index.cshtml
+++ b/ClientsApp/Views/Executor/Index.cshtml
@@ -8,7 +8,7 @@
 
 <p>На цій сторінці Виконавці Ви можете отримати усю інформацію по усіх виконавцях фірми,  а також додавати інформацію, редагувати та видаляти її. </p>
 
-<a asp-action="Create" class="btn btn-primary mb-3">Додати Виконавця</a>
+<a asp-action="Create" class="btn btn-success mb-2">Додати Виконавця</a>
 
 <table class="table table-striped">
     <thead>
@@ -25,11 +25,10 @@
                 <td>@executor.FullName</td>
                 <td>@executor.HourlyRate</td>
                 <td>
-                    <a asp-action="Edit" asp-route-id="@executor.ExecutorId" class="btn btn-sm btn-warning">Редагувати</a>
-                    <a asp-action="Delete" asp-route-id="@executor.ExecutorId" class="btn btn-sm btn-danger">Видалити</a>
+                    <a asp-action="Edit" asp-route-id="@executor.ExecutorId" class="btn btn-primary btn-sm">Редагувати</a>
+                    <a asp-action="Delete" asp-route-id="@executor.ExecutorId" class="btn btn-danger btn-sm">Видалити</a>
                 </td>
             </tr>
         }
     </tbody>
-</table>
 </table>

--- a/ClientsApp/Views/ExecutorTask/Edit.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Edit.cshtml
@@ -63,7 +63,7 @@
         <label>Вартість</label>
         <input id="TaskCost" class="form-control" value="@Model.TaskCost.ToString("F2")" readonly />
     </div>
-    <button type="submit" class="btn btn-primary">Зберегти</button>
+    <button type="submit" class="btn btn-success">Зберегти</button>
     <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
 </form>
 

--- a/ClientsApp/Views/Home/Index.cshtml
+++ b/ClientsApp/Views/Home/Index.cshtml
@@ -1,19 +1,56 @@
-﻿@{
+@{
     ViewData["Title"] = "Головна сторінка";
-   
 }
 
-<h1>Вітаємо в системі обліку клієнтів ClientsApp!</h1>
+<div class="text-center my-5">
+    <h1 class="display-4">Вітаємо в системі обліку клієнтів ClientsApp!</h1>
+    <p class="lead">Цей застосунок допомагає керувати клієнтами, завданнями, робочим часом та оплатами.</p>
+</div>
 
-<p>Цей застосунок призначений для ведення обліку клієнтів, виконання завдань для клієнтів, вартості послуг та оплат. </p>
-
-<p>
-    Перейдіть до керування:
-</p>
-<ul>
-    <li><a href="@Url.Action("Index", "Client")">Клієнти</a></li>
-    <li><a href="@Url.Action("Index", "Executor")">Виконавці</a></li>
-    <li><a href="@Url.Action("Index", "ClientTask")">Завдання</a></li>
-    <li><a href="@Url.Action("Index", "ExecutorTask")">Облік робочого часу</a></li>
-    <li><a href="@Url.Action("Index", "Payment")">Оплати</a></li>
-</ul>
+<div class="row">
+    <div class="col-md-4 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">Клієнти</h5>
+                <p class="card-text">Керуйте інформацією про клієнтів.</p>
+                <a href="@Url.Action("Index", "Client")" class="btn btn-primary">Перейти</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">Виконавці</h5>
+                <p class="card-text">Додавайте та редагуйте виконавців.</p>
+                <a href="@Url.Action("Index", "Executor")" class="btn btn-primary">Перейти</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">Завдання</h5>
+                <p class="card-text">Створюйте та відстежуйте завдання клієнтів.</p>
+                <a href="@Url.Action("Index", "ClientTask")" class="btn btn-primary">Перейти</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">Облік робочого часу</h5>
+                <p class="card-text">Фіксуйте витрати часу виконавців.</p>
+                <a href="@Url.Action("Index", "ExecutorTask")" class="btn btn-primary">Перейти</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">Оплати</h5>
+                <p class="card-text">Переглядайте та додавайте платежі.</p>
+                <a href="@Url.Action("Index", "Payment")" class="btn btn-primary">Перейти</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/ClientsApp/Views/Payment/Edit.cshtml
+++ b/ClientsApp/Views/Payment/Edit.cshtml
@@ -22,6 +22,6 @@
         <input asp-for="PaymentDate" class="form-control" type="date" />
         <span asp-validation-for="PaymentDate" class="text-danger"></span>
     </div>
-    <button type="submit" class="btn btn-primary">Зберегти</button>
+    <button type="submit" class="btn btn-success">Зберегти</button>
     <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
 </form>

--- a/ClientsApp/Views/Payment/Index.cshtml
+++ b/ClientsApp/Views/Payment/Index.cshtml
@@ -8,21 +8,23 @@
 <p>Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів. </p>
 
 
-<form method="get" class="form-inline mb-3">
-    <div class="form-group mr-2">
-        <select asp-for="SelectedClientId" asp-items="Model.Clients" class="form-control">
+<form method="get" class="row g-3 mb-3">
+    <div class="col-md-4">
+        <select asp-for="SelectedClientId" asp-items="Model.Clients" class="form-select">
             <option value="">Всі клієнти</option>
         </select>
     </div>
-    <div class="form-group mr-2">
-        <select asp-for="IsPaid" class="form-control">
+    <div class="col-md-4">
+        <select asp-for="IsPaid" class="form-select">
             <option value="">Всі</option>
             <option value="true">Оплачені</option>
             <option value="false">Неоплачені</option>
         </select>
     </div>
-    <button type="submit" class="btn btn-primary">Фільтрувати</button>
-    <a asp-action="Index" class="btn btn-secondary ms-2" id="resetFilters">Скинути усі фільтри</a>
+    <div class="col-md-4 d-flex align-items-end">
+        <button type="submit" class="btn btn-primary me-2">Фільтрувати</button>
+        <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути усі фільтри</a>
+    </div>
 </form>
 
 <a asp-action="Create" class="btn btn-success mb-2">Додати платіж</a>


### PR DESCRIPTION
## Summary
- Harmonize button classes so Add uses success, Edit primary, and Delete danger across pages
- Standardize filter forms using Bootstrap grids like on the ExecutorTask page
- Refresh the home page with a card-based layout for quick navigation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f686f47e48328aefa429b8a0a704d