### PR TITLE
Use brand as home link and style hover/focus

### DIFF
--- a/ClientsApp/Views/Shared/_Layout.cshtml
+++ b/ClientsApp/Views/Shared/_Layout.cshtml
@@ -17,9 +17,6 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Home" ? "active" : "")" asp-controller="Home" asp-action="Index">Головна</a>
-                    </li>
-                    <li class="nav-item">
                         <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Client" ? "active" : "")" asp-controller="Client" asp-action="Index">Клієнти</a>
                     </li>
                     <li class="nav-item">

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -47,6 +47,13 @@ body {
     text-decoration: underline;
 }
 
+/* Navbar brand link styles */
+.navbar-brand:hover,
+.navbar-brand:focus {
+    color: #0d6efd;
+    text-decoration: none;
+}
+
 /* Home page links */
 .home-links a {
     display: block;


### PR DESCRIPTION
## Summary
- Remove redundant 'Головна' navigation item, using brand as home link
- Add hover and focus styles to navbar brand link without underline

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a31bf539bc8328afe0fcf3dc7e661d