### PR TITLE
Add ASP.NET Identity authentication and role-based authorization

### DIFF
--- a/ClientsApp/ClientsApp.csproj
+++ b/ClientsApp/ClientsApp.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.21.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>

--- a/ClientsApp/Controllers/AccountController.cs
+++ b/ClientsApp/Controllers/AccountController.cs
@@ -1,0 +1,139 @@
+using ClientsApp.Models;
+using ClientsApp.Models.ViewModels.Account;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClientsApp.Controllers
+{
+    [AllowAnonymous]
+    public class AccountController : Controller
+    {
+        private static readonly string[] AllowedRoles = ["Manager", "Accountant", "Executor"];
+
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly ApplicationDbContext _context;
+
+        public AccountController(
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
+            ApplicationDbContext context)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _context = context;
+        }
+
+        [HttpGet]
+        public IActionResult Register()
+        {
+            ViewBag.Roles = AllowedRoles;
+            return View(new RegisterViewModel());
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Register(RegisterViewModel model)
+        {
+            ViewBag.Roles = AllowedRoles;
+
+            if (!AllowedRoles.Contains(model.Role))
+            {
+                ModelState.AddModelError(nameof(model.Role), "Оберіть коректну роль.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var user = new ApplicationUser
+            {
+                UserName = model.Email,
+                Email = model.Email
+            };
+
+            if (model.Role == "Executor")
+            {
+                var executor = await _context.Executors.FirstOrDefaultAsync(e => e.Email == model.Email);
+                if (executor == null)
+                {
+                    ModelState.AddModelError(nameof(model.Email), "Для ролі Executor потрібен існуючий виконавець з таким email.");
+                    return View(model);
+                }
+
+                user.ExecutorId = executor.ExecutorId;
+            }
+
+            var result = await _userManager.CreateAsync(user, model.Password);
+            if (!result.Succeeded)
+            {
+                foreach (var error in result.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+
+                return View(model);
+            }
+
+            await _userManager.AddToRoleAsync(user, model.Role);
+            await _signInManager.SignInAsync(user, isPersistent: false);
+
+            return RedirectToAction("Index", "Home");
+        }
+
+        [HttpGet]
+        public IActionResult Login(string? returnUrl = null)
+        {
+            ViewData["ReturnUrl"] = returnUrl;
+            return View(new LoginViewModel());
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Login(LoginViewModel model, string? returnUrl = null)
+        {
+            ViewData["ReturnUrl"] = returnUrl;
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var result = await _signInManager.PasswordSignInAsync(model.Email, model.Password, model.RememberMe, lockoutOnFailure: false);
+            if (result.Succeeded)
+            {
+                return RedirectToLocal(returnUrl);
+            }
+
+            ModelState.AddModelError(string.Empty, "Невірна спроба входу.");
+            return View(model);
+        }
+
+        [Authorize]
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Logout()
+        {
+            await _signInManager.SignOutAsync();
+            return RedirectToAction("Index", "Home");
+        }
+
+        [HttpGet]
+        public IActionResult AccessDenied()
+        {
+            return View();
+        }
+
+        private IActionResult RedirectToLocal(string? returnUrl)
+        {
+            if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
+            {
+                return Redirect(returnUrl);
+            }
+
+            return RedirectToAction("Index", "Home");
+        }
+    }
+}

--- a/ClientsApp/Controllers/ClientController.cs
+++ b/ClientsApp/Controllers/ClientController.cs
@@ -1,5 +1,6 @@
 ﻿using ClientsApp.BLL.Interfaces;
 using ClientsApp.Models.Entities;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace ClientsApp.Controllers
 {
+    [Authorize(Roles = "Manager")]
     public class ClientController : Controller
     {
         private readonly IClientService _clientService;

--- a/ClientsApp/Controllers/ClientTaskController.cs
+++ b/ClientsApp/Controllers/ClientTaskController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
 using System.Linq;
@@ -9,6 +10,7 @@ using ClientsApp.BLL.Interfaces;
 
 namespace ClientsApp.Controllers
 {
+    [Authorize(Roles = "Manager")]
     public class ClientTaskController : Controller
     {
         private readonly IClientTaskService _taskService;

--- a/ClientsApp/Controllers/ExecutorController.cs
+++ b/ClientsApp/Controllers/ExecutorController.cs
@@ -1,5 +1,6 @@
 ﻿using ClientsApp.BLL.Interfaces;
 using ClientsApp.Models.Entities;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Globalization;
@@ -7,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace ClientsApp.Controllers
 {
+    [Authorize(Roles = "Manager")]
     public class ExecutorController : Controller
     {
         private readonly IExecutorService _executorService;

--- a/ClientsApp/Controllers/ExecutorTaskController.cs
+++ b/ClientsApp/Controllers/ExecutorTaskController.cs
@@ -1,29 +1,33 @@
 using ClientsApp.BLL.Interfaces;
 using ClientsApp.Models.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ClientsApp.Controllers
 {
+    [Authorize(Roles = "Manager")]
     public class ExecutorTaskController : Controller
     {
         private readonly IExecutorTaskService _executorTaskService;
         private readonly IExecutorService _executorService;
         private readonly IClientService _clientService;
         private readonly IClientTaskService _clientTaskService;
+        private readonly UserManager<Models.ApplicationUser> _userManager;
 
         public ExecutorTaskController(
             IExecutorTaskService executorTaskService,
             IExecutorService executorService,
             IClientService clientService,
-            IClientTaskService clientTaskService)
+            IClientTaskService clientTaskService,
+            UserManager<Models.ApplicationUser> userManager)
         {
             _executorTaskService = executorTaskService;
             _executorService = executorService;
             _clientService = clientService;
             _clientTaskService = clientTaskService;
+            _userManager = userManager;
         }
 
         public async Task<IActionResult> Index(int? executorId, int? clientId, int? taskId)
@@ -61,10 +65,21 @@ namespace ClientsApp.Controllers
             return View(executorTask);
         }
 
+        [Authorize(Roles = "Manager,Executor")]
         public async Task<IActionResult> Edit(int id)
         {
             var executorTask = await _executorTaskService.GetByIdAsync(id);
             if (executorTask == null) return NotFound();
+
+            if (User.IsInRole("Executor"))
+            {
+                if (!await CanExecutorEditTaskAsync(executorTask))
+                {
+                    return Forbid();
+                }
+
+                return View("EditActualTime", executorTask);
+            }
 
             ViewBag.Executors = await _executorService.GetAllAsync();
             ViewBag.Clients = await _executorTaskService.GetClientsByExecutorAsync(executorTask.ExecutorId ?? 0);
@@ -75,15 +90,35 @@ namespace ClientsApp.Controllers
             return View(executorTask);
         }
 
+        [Authorize(Roles = "Manager,Executor")]
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(ExecutorTask executorTask)
         {
+            if (User.IsInRole("Executor"))
+            {
+                var existingTask = await _executorTaskService.GetByIdAsync(executorTask.ExecutorTaskId);
+                if (existingTask == null)
+                {
+                    return NotFound();
+                }
+
+                if (!await CanExecutorEditTaskAsync(existingTask))
+                {
+                    return Forbid();
+                }
+
+                existingTask.ActualTime = executorTask.ActualTime;
+                await _executorTaskService.UpdateAsync(existingTask);
+                return RedirectToAction("Index", "Home");
+            }
+
             if (ModelState.IsValid)
             {
                 await _executorTaskService.UpdateAsync(executorTask);
                 return RedirectToAction(nameof(Index));
             }
+
             ViewBag.Executors = await _executorService.GetAllAsync();
             ViewBag.Clients = await _executorTaskService.GetClientsByExecutorAsync(executorTask.ExecutorId ?? 0);
             var clientId = executorTask.ClientId ?? (await _executorTaskService.GetByIdAsync(executorTask.ExecutorTaskId))?.ClientTask?.ClientId ?? 0;
@@ -119,6 +154,17 @@ namespace ClientsApp.Controllers
         {
             var tasks = await _executorTaskService.GetTasksByExecutorAndClientAsync(executorId, clientId);
             return Json(tasks.Select(t => new { t.ClientTaskId, t.TaskTitle }));
+        }
+
+        private async Task<bool> CanExecutorEditTaskAsync(ExecutorTask executorTask)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null || !user.ExecutorId.HasValue)
+            {
+                return false;
+            }
+
+            return executorTask.ExecutorId == user.ExecutorId.Value;
         }
     }
 }

--- a/ClientsApp/Controllers/PaymentController.cs
+++ b/ClientsApp/Controllers/PaymentController.cs
@@ -1,14 +1,13 @@
 using ClientsApp.BLL.Interfaces;
 using ClientsApp.Models.Entities;
 using ClientsApp.Models.ViewModels;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ClientsApp.Controllers
 {
+    [Authorize(Roles = "Manager")]
     public class PaymentController : Controller
     {
         private readonly IPaymentService _paymentService;
@@ -69,12 +68,14 @@ namespace ClientsApp.Controllers
             return View(model);
         }
 
+        [Authorize(Roles = "Manager,Accountant")]
         public async Task<IActionResult> Create()
         {
             await PopulateTasks();
             return View();
         }
 
+        [Authorize(Roles = "Manager,Accountant")]
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(Payment payment)
@@ -88,6 +89,11 @@ namespace ClientsApp.Controllers
             payment.PaymentDate = DateTime.Now;
             payment.BalanceDue = await CalculateBalanceDue(payment.ClientTaskId, payment.Amount, null);
             await _paymentService.AddAsync(payment);
+            if (User.IsInRole("Accountant"))
+            {
+                return RedirectToAction("Create");
+            }
+
             return RedirectToAction(nameof(Index));
         }
 

--- a/ClientsApp/Controllers/StatisticsController.cs
+++ b/ClientsApp/Controllers/StatisticsController.cs
@@ -10,11 +10,13 @@ using ClientsApp.Models.ViewModels.Statistics;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace ClientsApp.Controllers
 {
+    [Authorize(Roles = "Manager")]
     public class StatisticsController : Controller
     {
         private readonly IClientService _clientService;

--- a/ClientsApp/Models/ApplicationDbContext.cs
+++ b/ClientsApp/Models/ApplicationDbContext.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using ClientsApp.Models.Entities;
 
 namespace ClientsApp.Models
 {
-    public class ApplicationDbContext : DbContext
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
 
@@ -15,6 +16,8 @@ namespace ClientsApp.Models
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            base.OnModelCreating(modelBuilder);
+
             modelBuilder.Entity<ClientTask>()
                 .Property(t => t.TaskStatus)
                 .HasConversion<int>();
@@ -27,6 +30,12 @@ namespace ClientsApp.Models
             modelBuilder.Entity<Executor>()
                 .Property(e => e.HourlyRate)
                 .HasColumnType("decimal(18,2)");
+
+            modelBuilder.Entity<Executor>()
+                .HasOne(e => e.ApplicationUser)
+                .WithOne(u => u.Executor)
+                .HasForeignKey<ApplicationUser>(u => u.ExecutorId)
+                .OnDelete(DeleteBehavior.SetNull);
 
             modelBuilder.Entity<ExecutorTask>()
                 .Property(et => et.ActualTime)
@@ -52,8 +61,6 @@ namespace ClientsApp.Models
                 .HasOne(et => et.ClientTask)
                 .WithMany(ct => ct.ExecutorTasks)
                 .HasForeignKey(et => et.ClientTaskId);
-
-            base.OnModelCreating(modelBuilder);
         }
 
     }

--- a/ClientsApp/Models/ApplicationUser.cs
+++ b/ClientsApp/Models/ApplicationUser.cs
@@ -1,0 +1,11 @@
+using ClientsApp.Models.Entities;
+using Microsoft.AspNetCore.Identity;
+
+namespace ClientsApp.Models
+{
+    public class ApplicationUser : IdentityUser
+    {
+        public int? ExecutorId { get; set; }
+        public Executor? Executor { get; set; }
+    }
+}

--- a/ClientsApp/Models/Entities/Executor.cs
+++ b/ClientsApp/Models/Entities/Executor.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace ClientsApp.Models.Entities
 {
+    using ClientsApp.Models;
     public class Executor : IValidatableObject
     {
         public int ExecutorId { get; set; }
@@ -52,6 +53,11 @@ namespace ClientsApp.Models.Entities
                     new[] { nameof(UnavailableTo) });
             }
         }
+
+
+        [Display(Name = "Користувач")]
+        public string? ApplicationUserId { get; set; }
+        public ApplicationUser? ApplicationUser { get; set; }
 
         public ICollection<ExecutorTask>? ExecutorTasks { get; set; }
 

--- a/ClientsApp/Models/ViewModels/Account/LoginViewModel.cs
+++ b/ClientsApp/Models/ViewModels/Account/LoginViewModel.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClientsApp.Models.ViewModels.Account
+{
+    public class LoginViewModel
+    {
+        [Required(ErrorMessage = "Email є обов'язковим")]
+        [EmailAddress(ErrorMessage = "Некоректний email")]
+        [Display(Name = "Email")]
+        public string Email { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Пароль є обов'язковим")]
+        [DataType(DataType.Password)]
+        [Display(Name = "Пароль")]
+        public string Password { get; set; } = string.Empty;
+
+        [Display(Name = "Запам'ятати мене")]
+        public bool RememberMe { get; set; }
+    }
+}

--- a/ClientsApp/Models/ViewModels/Account/RegisterViewModel.cs
+++ b/ClientsApp/Models/ViewModels/Account/RegisterViewModel.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClientsApp.Models.ViewModels.Account
+{
+    public class RegisterViewModel
+    {
+        [Required(ErrorMessage = "Email є обов'язковим")]
+        [EmailAddress(ErrorMessage = "Некоректний email")]
+        [Display(Name = "Email")]
+        public string Email { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Пароль є обов'язковим")]
+        [DataType(DataType.Password)]
+        [StringLength(100, MinimumLength = 6, ErrorMessage = "Пароль має містити щонайменше 6 символів")]
+        [Display(Name = "Пароль")]
+        public string Password { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Підтвердження пароля є обов'язковим")]
+        [DataType(DataType.Password)]
+        [Compare(nameof(Password), ErrorMessage = "Паролі не співпадають")]
+        [Display(Name = "Підтвердження пароля")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Оберіть роль")]
+        [Display(Name = "Роль")]
+        public string Role { get; set; } = string.Empty;
+    }
+}

--- a/ClientsApp/Program.cs
+++ b/ClientsApp/Program.cs
@@ -1,14 +1,33 @@
-using Microsoft.EntityFrameworkCore;
-using ClientsApp.Models;
-using ClientsApp.BLL.Interfaces;
-using ClientsApp.BLL.Services;
 using AutoMapper;
 using ClientsApp.BLL;
+using ClientsApp.BLL.Interfaces;
+using ClientsApp.BLL.Services;
+using ClientsApp.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services
+    .AddIdentity<ApplicationUser, IdentityRole>(options =>
+    {
+        options.Password.RequireDigit = true;
+        options.Password.RequireLowercase = true;
+        options.Password.RequireUppercase = false;
+        options.Password.RequireNonAlphanumeric = false;
+        options.Password.RequiredLength = 6;
+    })
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddDefaultTokenProviders();
+
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.LoginPath = "/Account/Login";
+    options.AccessDeniedPath = "/Account/AccessDenied";
+});
 
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
@@ -26,6 +45,16 @@ using (var scope = app.Services.CreateScope())
 {
     var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     dbContext.Database.Migrate();
+
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+    string[] roles = ["Manager", "Accountant", "Executor"];
+    foreach (var role in roles)
+    {
+        if (!await roleManager.RoleExistsAsync(role))
+        {
+            await roleManager.CreateAsync(new IdentityRole(role));
+        }
+    }
 }
 
 if (!app.Environment.IsDevelopment())
@@ -39,6 +68,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllerRoute(

--- a/ClientsApp/Views/Account/AccessDenied.cshtml
+++ b/ClientsApp/Views/Account/AccessDenied.cshtml
@@ -1,0 +1,7 @@
+@{
+    ViewData["Title"] = "Доступ заборонено";
+}
+
+<div class="alert alert-danger mt-3">
+    У вас немає прав доступу до цієї сторінки.
+</div>

--- a/ClientsApp/Views/Account/Login.cshtml
+++ b/ClientsApp/Views/Account/Login.cshtml
@@ -1,0 +1,35 @@
+@model ClientsApp.Models.ViewModels.Account.LoginViewModel
+@{
+    ViewData["Title"] = "Вхід";
+}
+
+<h2>Вхід</h2>
+
+<form asp-action="Login" method="post" class="mt-3">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <input type="hidden" name="returnUrl" value="@ViewData["ReturnUrl"]" />
+
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Password" class="form-label"></label>
+        <input asp-for="Password" class="form-control" />
+        <span asp-validation-for="Password" class="text-danger"></span>
+    </div>
+
+    <div class="form-check mb-3">
+        <input asp-for="RememberMe" class="form-check-input" />
+        <label asp-for="RememberMe" class="form-check-label"></label>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Увійти</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/ClientsApp/Views/Account/Register.cshtml
+++ b/ClientsApp/Views/Account/Register.cshtml
@@ -1,0 +1,47 @@
+@model ClientsApp.Models.ViewModels.Account.RegisterViewModel
+@{
+    ViewData["Title"] = "Реєстрація";
+}
+
+<h2>Реєстрація</h2>
+
+<form asp-action="Register" method="post" class="mt-3">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Role" class="form-label"></label>
+        <select asp-for="Role" class="form-select">
+            <option value="">Оберіть роль</option>
+            @foreach (var role in (string[])ViewBag.Roles)
+            {
+                <option value="@role">@role</option>
+            }
+        </select>
+        <span asp-validation-for="Role" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Password" class="form-label"></label>
+        <input asp-for="Password" class="form-control" />
+        <span asp-validation-for="Password" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="ConfirmPassword" class="form-label"></label>
+        <input asp-for="ConfirmPassword" class="form-control" />
+        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Зареєструватися</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/ClientsApp/Views/ExecutorTask/EditActualTime.cshtml
+++ b/ClientsApp/Views/ExecutorTask/EditActualTime.cshtml
@@ -1,0 +1,41 @@
+@model ClientsApp.Models.Entities.ExecutorTask
+
+@{
+    ViewData["Title"] = "Редагування фактичного часу";
+}
+
+<h1>Редагування фактичного часу</h1>
+
+<h4>Завдання виконавця</h4>
+<hr />
+<div class="row">
+    <div class="col-md-6">
+        <form asp-action="Edit" method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="ExecutorTaskId" />
+
+            <div class="mb-3">
+                <label class="form-label">Виконавець</label>
+                <input class="form-control" value="@Model.Executor?.FullName" readonly />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Завдання</label>
+                <input class="form-control" value="@Model.ClientTask?.TaskTitle" readonly />
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="ActualTime" class="form-label"></label>
+                <input asp-for="ActualTime" class="form-control" />
+                <span asp-validation-for="ActualTime" class="text-danger"></span>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Зберегти</button>
+            <a asp-controller="Home" asp-action="Index" class="btn btn-secondary">Назад</a>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/ClientsApp/Views/Shared/_Layout.cshtml
+++ b/ClientsApp/Views/Shared/_Layout.cshtml
@@ -9,32 +9,61 @@
 </head>
 <body class="d-flex flex-column min-vh-100">
     <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
-        <div class="container">            
+        <div class="container">
             <a class="navbar-brand fs-2 fw-bold" asp-area="" asp-controller="Home" asp-action="Index">ClientsApp</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Перемкнути навігацію">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Client" ? "active" : "")" asp-controller="Client" asp-action="Index">Клієнти</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Executor" ? "active" : "")" asp-controller="Executor" asp-action="Index">Виконавці</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ClientTask" ? "active" : "")" asp-controller="ClientTask" asp-action="Index">Завдання</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ExecutorTask" ? "active" : "")" asp-controller="ExecutorTask" asp-action="Index">Облік робочого часу</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Payment" ? "active" : "")" asp-controller="Payment" asp-action="Index">Оплати</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Statistics" ? "active" : "")" asp-controller="Statistics" asp-action="Index">Статистики та звіти</a>
-                    </li>
-                </ul>
+                @if (User.Identity?.IsAuthenticated == true)
+                {
+                    <ul class="navbar-nav me-auto">
+                        @if (User.IsInRole("Manager"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Client" ? "active" : "")" asp-controller="Client" asp-action="Index">Клієнти</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Executor" ? "active" : "")" asp-controller="Executor" asp-action="Index">Виконавці</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ClientTask" ? "active" : "")" asp-controller="ClientTask" asp-action="Index">Завдання</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ExecutorTask" ? "active" : "")" asp-controller="ExecutorTask" asp-action="Index">Облік робочого часу</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Payment" ? "active" : "")" asp-controller="Payment" asp-action="Index">Оплати</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Statistics" ? "active" : "")" asp-controller="Statistics" asp-action="Index">Статистики та звіти</a>
+                            </li>
+                        }
+                        @if (User.IsInRole("Accountant"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Payment" && ViewContext.RouteData.Values["action"]?.ToString() == "Create" ? "active" : "")" asp-controller="Payment" asp-action="Create">Створення оплати</a>
+                            </li>
+                        }
+                    </ul>
+
+                    <ul class="navbar-nav ms-auto">
+                        <li class="nav-item me-2 align-self-center text-muted">@User.Identity.Name</li>
+                        <li class="nav-item">
+                            <form asp-controller="Account" asp-action="Logout" method="post">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn-outline-secondary btn-sm">Вийти</button>
+                            </form>
+                        </li>
+                    </ul>
+                }
+                else
+                {
+                    <ul class="navbar-nav ms-auto">
+                        <li class="nav-item"><a class="nav-link" asp-controller="Account" asp-action="Login">Вхід</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-controller="Account" asp-action="Register">Реєстрація</a></li>
+                    </ul>
+                }
             </div>
         </div>
     </nav>


### PR DESCRIPTION
### Motivation
- Add authentication and role-based authorization so the app supports registration, login/logout and three roles (`Manager`, `Accountant`, `Executor`).
- Link Identity users with existing `Executor` entities so Executors can be restricted to editing only their own tasks.
- Enforce server-side security to prevent unauthorized direct POSTs and overposting (Executors may only change `ActualTime`).

### Description
- Introduced `ApplicationUser` and made `ApplicationDbContext` inherit from `IdentityDbContext<ApplicationUser>`, added Identity EF Core package and configured Identity and cookie options in `Program.cs`, and create roles on startup (`Manager`, `Accountant`, `Executor`).
- Implemented account flows: `AccountController`, `RegisterViewModel`/`LoginViewModel`, and Razor views (`Register`, `Login`, `AccessDenied`), with server-side validation that an `Executor` user maps to an existing `Executor` record by email.
- Applied role-based authorization attributes: `Manager` for main management controllers, `Manager,Accountant` for payment creation, and `Manager,Executor` for executor task editing; updated `_Layout` to show role-appropriate navigation and auth actions.
- Secured executor edits by adding `EditActualTime` view and controller logic that verifies the current user is linked to the `Executor` and updates only the `ActualTime` field (existing entity is loaded and only that property is changed), plus a `CanExecutorEditTaskAsync` helper.

### Testing
- Performed a repository status check to confirm the working tree and changed files were present — succeeded.
- Attempted to generate EF migrations with `dotnet ef migrations add AddIdentityAuthAndRoles` but the environment lacks the `dotnet` CLI, so migration generation failed (`dotnet: command not found`) — failed.
- No project build or unit tests were executed in this environment due to missing .NET tooling (please run `dotnet build`, `dotnet ef migrations add` and tests in a .NET-enabled environment before deployment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de0b798e4083289ceb5665cb14471d)