### PR TITLE
Restrict public registration and seed initial Manager user

### DIFF
--- a/ClientsApp/Controllers/AccountController.cs
+++ b/ClientsApp/Controllers/AccountController.cs
@@ -7,10 +7,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ClientsApp.Controllers
 {
-    [AllowAnonymous]
     public class AccountController : Controller
     {
-        private static readonly string[] AllowedRoles = ["Manager", "Accountant", "Executor"];
+        private static readonly string[] AllowedRoles = ["Accountant", "Executor"];
 
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
@@ -26,6 +25,7 @@ namespace ClientsApp.Controllers
             _context = context;
         }
 
+        [Authorize(Roles = "Manager")]
         [HttpGet]
         public IActionResult Register()
         {
@@ -33,6 +33,7 @@ namespace ClientsApp.Controllers
             return View(new RegisterViewModel());
         }
 
+        [Authorize(Roles = "Manager")]
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Register(RegisterViewModel model)
@@ -79,11 +80,11 @@ namespace ClientsApp.Controllers
             }
 
             await _userManager.AddToRoleAsync(user, model.Role);
-            await _signInManager.SignInAsync(user, isPersistent: false);
 
             return RedirectToAction("Index", "Home");
         }
 
+        [AllowAnonymous]
         [HttpGet]
         public IActionResult Login(string? returnUrl = null)
         {
@@ -91,6 +92,7 @@ namespace ClientsApp.Controllers
             return View(new LoginViewModel());
         }
 
+        [AllowAnonymous]
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Login(LoginViewModel model, string? returnUrl = null)
@@ -120,6 +122,7 @@ namespace ClientsApp.Controllers
             return RedirectToAction("Index", "Home");
         }
 
+        [AllowAnonymous]
         [HttpGet]
         public IActionResult AccessDenied()
         {

--- a/ClientsApp/Program.cs
+++ b/ClientsApp/Program.cs
@@ -63,6 +63,7 @@ using (var scope = app.Services.CreateScope())
 
     await EnsureIdentitySchemaAsync(dbContext, logger);
     await SeedRolesAsync(scope.ServiceProvider, logger);
+    await SeedFirstManagerAsync(scope.ServiceProvider, builder.Configuration, logger);
 }
 
 if (!app.Environment.IsDevelopment())
@@ -84,6 +85,60 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
+
+
+static async Task SeedFirstManagerAsync(IServiceProvider serviceProvider, IConfiguration configuration, ILogger logger)
+{
+    var userManager = serviceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+    var managers = await userManager.GetUsersInRoleAsync("Manager");
+    if (managers.Count > 0)
+    {
+        return;
+    }
+
+    var seedManagerEmail = configuration["SeedAdmin:Email"];
+    var seedManagerPassword = configuration["SeedAdmin:Password"];
+
+    if (string.IsNullOrWhiteSpace(seedManagerEmail) || string.IsNullOrWhiteSpace(seedManagerPassword))
+    {
+        logger.LogWarning("No users with Manager role were found, but SeedAdmin credentials are missing in configuration. Set SeedAdmin:Email and SeedAdmin:Password.");
+        return;
+    }
+
+    var existingUser = await userManager.FindByEmailAsync(seedManagerEmail);
+    if (existingUser is null)
+    {
+        existingUser = new ApplicationUser
+        {
+            UserName = seedManagerEmail,
+            Email = seedManagerEmail
+        };
+
+        var createResult = await userManager.CreateAsync(existingUser, seedManagerPassword);
+        if (!createResult.Succeeded)
+        {
+            logger.LogWarning("Failed to create seed manager user {Email}: {Errors}",
+                seedManagerEmail,
+                string.Join("; ", createResult.Errors.Select(e => e.Description)));
+            return;
+        }
+    }
+
+    if (!await userManager.IsInRoleAsync(existingUser, "Manager"))
+    {
+        var addRoleResult = await userManager.AddToRoleAsync(existingUser, "Manager");
+        if (!addRoleResult.Succeeded)
+        {
+            logger.LogWarning("Failed to assign Manager role to user {Email}: {Errors}",
+                seedManagerEmail,
+                string.Join("; ", addRoleResult.Errors.Select(e => e.Description)));
+            return;
+        }
+    }
+
+    logger.LogInformation("Seed manager user is available: {Email}", seedManagerEmail);
+}
 
 static async Task SeedRolesAsync(IServiceProvider serviceProvider, ILogger logger)
 {

--- a/ClientsApp/Views/Account/Register.cshtml
+++ b/ClientsApp/Views/Account/Register.cshtml
@@ -1,9 +1,9 @@
 @model ClientsApp.Models.ViewModels.Account.RegisterViewModel
 @{
-    ViewData["Title"] = "Реєстрація";
+    ViewData["Title"] = "Створення користувача";
 }
 
-<h2>Реєстрація</h2>
+<h2>Створення користувача</h2>
 
 <form asp-action="Register" method="post" class="mt-3">
     @Html.AntiForgeryToken()
@@ -39,7 +39,7 @@
         <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
     </div>
 
-    <button type="submit" class="btn btn-primary">Зареєструватися</button>
+    <button type="submit" class="btn btn-primary">Створити користувача</button>
 </form>
 
 @section Scripts {

--- a/ClientsApp/Views/Shared/_Layout.cshtml
+++ b/ClientsApp/Views/Shared/_Layout.cshtml
@@ -41,6 +41,12 @@
                     <ul class="navbar-nav ms-auto">
                         <li class="nav-item me-2 align-self-center text-muted">@User.Identity.Name</li>
                         <li class="nav-item">
+                            @if (User.IsInRole("Manager"))
+                            {
+                                <a class="nav-link" asp-controller="Account" asp-action="Register">Створити користувача</a>
+                            }
+                        </li>
+                        <li class="nav-item">
                             <form asp-controller="Account" asp-action="Logout" method="post">
                                 @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-outline-secondary btn-sm">Вийти</button>
@@ -52,7 +58,6 @@
                 {
                     <ul class="navbar-nav ms-auto">
                         <li class="nav-item"><a class="nav-link" asp-controller="Account" asp-action="Login">Вхід</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-controller="Account" asp-action="Register">Реєстрація</a></li>
                     </ul>
                 }
             </div>

--- a/ClientsApp/appsettings.Development.json
+++ b/ClientsApp/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "SeedAdmin": {
+    "Email": "manager@example.com",
+    "Password": "ChangeMe123"
   }
 }

--- a/ClientsApp/appsettings.json
+++ b/ClientsApp/appsettings.json
@@ -9,5 +9,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "SeedAdmin": {
+    "Email": "manager@example.com",
+    "Password": "ChangeMe123"
+  }
 }


### PR DESCRIPTION
### Motivation
- Prevent public self-registration so only Managers can create new users while keeping existing role model and login behavior unchanged.
- Ensure the application always has at least one Manager by creating a seed Manager on startup when none exist, without hardcoding credentials in code.

### Description
- Restricted `AccountController.Register` (GET/POST) with `[Authorize(Roles = "Manager")]`, limited allowed roles to `Accountant` and `Executor`, and removed automatic sign-in after creation to prevent manager-created users from being logged in immediately.
- Added `SeedFirstManagerAsync` in `Program.cs` and invoked it at startup to create the first Manager only if no Manager exists, reading credentials from configuration keys `SeedAdmin:Email` and `SeedAdmin:Password` and leaving existing users/roles intact.
- Kept `Login` actions public (`[AllowAnonymous]`) and preserved existing authorization rules elsewhere so sign-in and role permissions are unchanged.
- Updated UI: removed public "Реєстрація" link for anonymous users, added a manager-only "Створити користувача" link in `_Layout.cshtml`, and adapted `Register.cshtml` text/buttons to reflect manager-driven user creation.
- Added `SeedAdmin` entries to `appsettings.json` and `appsettings.Development.json` (example values provided) so initial Manager credentials are configurable.

### Testing
- Attempted to run `dotnet build ClientsApp.sln`, but the .NET SDK is not available in this environment (`dotnet: command not found`), so a full build/test run could not be executed here.
- Verified code changes by running local file inspections and ensuring application startup hooks and controller attributes are present as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1fd36a53c8328a261f7b6406704ae)