### PR TITLE
Додати поле DismissedFrom, фільтр/сортування виконавців та попередження при призначенні завдання

### DIFF
--- a/ClientsApp/Controllers/ClientTaskController.cs
+++ b/ClientsApp/Controllers/ClientTaskController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using ClientsApp.Models.Entities;
 using ClientsApp.Models.ViewModels;
 using ClientsApp.BLL.Interfaces;
+using System.Collections.Generic;
 
 namespace ClientsApp.Controllers
 {
@@ -68,12 +69,7 @@ namespace ClientsApp.Controllers
         [Authorize(Roles = "Manager")]
         public async Task<IActionResult> Create()
         {
-            ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name");
-            var availableExecutors = (await _executorService.GetAllAsync())
-                .Where(e => !e.UnavailableFrom.HasValue && !e.UnavailableTo.HasValue)
-                .ToList();
-            ViewBag.Executors = new MultiSelectList(availableExecutors, "ExecutorId", "FullName");
-            ViewBag.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)));
+            await PopulateCreateViewBagsAsync();
             return View();
         }
 
@@ -84,12 +80,41 @@ namespace ClientsApp.Controllers
         {
             if (!ModelState.IsValid)
             {
-                ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", task.ClientId);
-                var availableExecutors = (await _executorService.GetAllAsync())
-                    .Where(e => !e.UnavailableFrom.HasValue && !e.UnavailableTo.HasValue)
-                    .ToList();
-                ViewBag.Executors = new MultiSelectList(availableExecutors, "ExecutorId", "FullName", selectedExecutors);
-                ViewBag.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), task.TaskStatus);
+                await PopulateCreateViewBagsAsync(task, selectedExecutors);
+                return View(task);
+            }
+
+            var startDate = task.StartDate.Date;
+            var selectedExecutorsData = (await _executorService.GetAllAsync())
+                .Where(e => selectedExecutors.Contains(e.ExecutorId))
+                .ToList();
+
+            var invalidUnavailableExecutors = selectedExecutorsData
+                .Where(e => e.UnavailableFrom.HasValue
+                    && e.UnavailableTo.HasValue
+                    && startDate >= e.UnavailableFrom.Value.Date
+                    && startDate <= e.UnavailableTo.Value.Date)
+                .Select(e => e.FullName)
+                .ToList();
+
+            if (invalidUnavailableExecutors.Count > 0)
+            {
+                ModelState.AddModelError(string.Empty, $"Обрані виконавці недоступні на дату початку: {string.Join(", ", invalidUnavailableExecutors)}.");
+            }
+
+            var dismissedExecutors = selectedExecutorsData
+                .Where(e => e.DismissedFrom.HasValue && startDate >= e.DismissedFrom.Value.Date)
+                .Select(e => e.FullName)
+                .ToList();
+
+            if (dismissedExecutors.Count > 0)
+            {
+                ModelState.AddModelError(string.Empty, $"Обрані виконавці звільнені на дату початку: {string.Join(", ", dismissedExecutors)}.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                await PopulateCreateViewBagsAsync(task, selectedExecutors);
                 return View(task);
             }
 
@@ -203,6 +228,19 @@ namespace ClientsApp.Controllers
         {
             await _taskService.DeleteAsync(id);
             return RedirectToAction(nameof(Index));
+        }
+
+        private async Task PopulateCreateViewBagsAsync(ClientTask? task = null, int[]? selectedExecutors = null)
+        {
+            var today = DateTime.Today;
+
+            ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", task?.ClientId);
+            ViewBag.Executors = (await _executorService.GetAllAsync())
+                .Where(e => !e.DismissedFrom.HasValue || e.DismissedFrom.Value.Date >= today)
+                .OrderBy(e => e.FullName)
+                .ToList();
+            ViewBag.SelectedExecutors = new HashSet<int>(selectedExecutors ?? Array.Empty<int>());
+            ViewBag.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), task?.TaskStatus);
         }
     }
 }

--- a/ClientsApp/Controllers/ExecutorController.cs
+++ b/ClientsApp/Controllers/ExecutorController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace ClientsApp.Controllers
@@ -18,17 +19,37 @@ namespace ClientsApp.Controllers
             _executorService = executorService;
         }
 
-        public async Task<IActionResult> Index(string? fullName, decimal? hourlyRate)
+        public async Task<IActionResult> Index(string? fullName, decimal? hourlyRate, string? statusFilter, string? sortOrder)
         {
             var hasFilters = !string.IsNullOrWhiteSpace(fullName) || hourlyRate.HasValue;
             var executors = hasFilters
                 ? await _executorService.SearchAsync(fullName, hourlyRate)
                 : await _executorService.GetAllAsync();
 
+            var today = DateTime.Today;
+            var normalizedStatus = string.IsNullOrWhiteSpace(statusFilter) ? "all" : statusFilter.ToLowerInvariant();
+            executors = normalizedStatus switch
+            {
+                "working" => executors.Where(e => !e.DismissedFrom.HasValue || e.DismissedFrom.Value.Date > today),
+                "dismissed" => executors.Where(e => e.DismissedFrom.HasValue && e.DismissedFrom.Value.Date <= today),
+                _ => executors
+            };
+
+            var normalizedSort = string.IsNullOrWhiteSpace(sortOrder) ? "id_desc" : sortOrder.ToLowerInvariant();
+            executors = normalizedSort switch
+            {
+                "name_asc" => executors.OrderBy(e => e.FullName),
+                "name_desc" => executors.OrderByDescending(e => e.FullName),
+                "id_asc" => executors.OrderBy(e => e.ExecutorId),
+                _ => executors.OrderByDescending(e => e.ExecutorId)
+            };
+
             ViewData["FullName"] = fullName;
             ViewData["HourlyRate"] = hourlyRate.HasValue
                 ? hourlyRate.Value.ToString(CultureInfo.InvariantCulture)
                 : null;
+            ViewData["StatusFilter"] = normalizedStatus;
+            ViewData["SortOrder"] = normalizedSort;
 
             return View(executors);
         }
@@ -99,6 +120,11 @@ namespace ClientsApp.Controllers
                 && executor.UnavailableTo.Value.Date < executor.UnavailableFrom.Value.Date)
             {
                 ModelState.AddModelError(nameof(Executor.UnavailableTo), "Дата \"Недоступний до\" не може бути раніше дати \"Недоступний з\".");
+            }
+
+            if (executor.DismissedFrom.HasValue && executor.DismissedFrom.Value.Date < today)
+            {
+                ModelState.AddModelError(nameof(Executor.DismissedFrom), "Дата \"Звільнений з дати\" не може бути раніше поточної дати.");
             }
         }
     }

--- a/ClientsApp/Migrations/20260417110000_AddExecutorDismissedFrom.cs
+++ b/ClientsApp/Migrations/20260417110000_AddExecutorDismissedFrom.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ClientsApp.Migrations
+{
+    public partial class AddExecutorDismissedFrom : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DismissedFrom",
+                table: "Executors",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DismissedFrom",
+                table: "Executors");
+        }
+    }
+}

--- a/ClientsApp/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/ClientsApp/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -104,6 +104,9 @@ namespace ClientsApp.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ExecutorId"));
 
+                    b.Property<DateTime?>("DismissedFrom")
+                        .HasColumnType("datetime2");
+
                     b.Property<string>("Email")
                         .HasColumnType("nvarchar(max)");
 

--- a/ClientsApp/Models/Entities/Executor.cs
+++ b/ClientsApp/Models/Entities/Executor.cs
@@ -33,6 +33,10 @@ namespace ClientsApp.Models.Entities
         [Display(Name = "Недоступний до")]
         public DateTime? UnavailableTo { get; set; }
 
+        [DataType(DataType.Date)]
+        [Display(Name = "Звільнений з дати")]
+        public DateTime? DismissedFrom { get; set; }
+
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             var today = DateTime.Today;
@@ -51,6 +55,13 @@ namespace ClientsApp.Models.Entities
                 yield return new ValidationResult(
                     "Дата \"Недоступний до\" не може бути раніше дати \"Недоступний з\".",
                     new[] { nameof(UnavailableTo) });
+            }
+
+            if (DismissedFrom.HasValue && DismissedFrom.Value.Date < today)
+            {
+                yield return new ValidationResult(
+                    "Дата \"Звільнений з дати\" не може бути раніше поточної дати.",
+                    new[] { nameof(DismissedFrom) });
             }
         }
         public ICollection<ExecutorTask>? ExecutorTasks { get; set; }

--- a/ClientsApp/Views/ClientTask/Create.cshtml
+++ b/ClientsApp/Views/ClientTask/Create.cshtml
@@ -3,6 +3,8 @@
 @{
     ViewData["Title"] = "Додати завдання";
     Layout = "_Layout";
+    var executors = ViewBag.Executors as IEnumerable<ClientsApp.Models.Entities.Executor> ?? new List<ClientsApp.Models.Entities.Executor>();
+    var selectedExecutors = ViewBag.SelectedExecutors as HashSet<int> ?? new HashSet<int>();
 }
 
 <h2>Додати завдання</h2>
@@ -42,7 +44,33 @@
 
     <div class="form-group">
         <label>Виконавці</label>
-        <select id="selectedExecutors" name="selectedExecutors" class="form-control" multiple asp-items="ViewBag.Executors"></select>
+        <select id="selectedExecutors" name="selectedExecutors" class="form-control" multiple>
+            @foreach (var executor in executors)
+            {
+                var unavailableFrom = executor.UnavailableFrom?.ToString("yyyy-MM-dd");
+                var unavailableTo = executor.UnavailableTo?.ToString("yyyy-MM-dd");
+                var dismissedFrom = executor.DismissedFrom?.ToString("yyyy-MM-dd");
+                if (selectedExecutors.Contains(executor.ExecutorId))
+                {
+                    <option value="@executor.ExecutorId"
+                            selected="selected"
+                            data-unavailable-from="@unavailableFrom"
+                            data-unavailable-to="@unavailableTo"
+                            data-dismissed-from="@dismissedFrom">
+                        @executor.FullName
+                    </option>
+                }
+                else
+                {
+                    <option value="@executor.ExecutorId"
+                            data-unavailable-from="@unavailableFrom"
+                            data-unavailable-to="@unavailableTo"
+                            data-dismissed-from="@dismissedFrom">
+                        @executor.FullName
+                    </option>
+                }
+            }
+        </select>
     </div>
 
     <div class="form-group">
@@ -78,17 +106,77 @@
     <script>
         (function () {
             const executorsSelect = document.getElementById('selectedExecutors');
+            const startDateInput = document.getElementById('StartDate');
             const modalElement = document.getElementById('inProgressTasksModal');
             const modalContent = document.getElementById('inProgressTasksContent');
-            if (!executorsSelect || !modalElement || !modalContent || !window.bootstrap) return;
+            if (!executorsSelect || !startDateInput || !modalElement || !modalContent || !window.bootstrap) return;
 
             const modal = new bootstrap.Modal(modalElement);
+            const parseDate = (value) => value ? new Date(`${value}T00:00:00`) : null;
+
+            const formatUaDate = (value) => {
+                const date = parseDate(value);
+                if (!date || Number.isNaN(date.getTime())) return '';
+                const day = String(date.getDate()).padStart(2, '0');
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                return `${day}.${month}.${date.getFullYear()}`;
+            };
+
+            const applyExecutorAvailability = () => {
+                const startDate = parseDate(startDateInput.value);
+                const options = Array.from(executorsSelect.options);
+                options.forEach(option => {
+                    const dismissedFrom = parseDate(option.dataset.dismissedFrom);
+                    const unavailableFrom = parseDate(option.dataset.unavailableFrom);
+                    const unavailableTo = parseDate(option.dataset.unavailableTo);
+
+                    let allowed = true;
+
+                    if (startDate && dismissedFrom && startDate >= dismissedFrom) {
+                        allowed = false;
+                    }
+
+                    if (startDate && unavailableFrom && unavailableTo && startDate >= unavailableFrom && startDate <= unavailableTo) {
+                        allowed = false;
+                    }
+
+                    option.hidden = !allowed;
+                    option.disabled = !allowed;
+                    if (!allowed) {
+                        option.selected = false;
+                    }
+                });
+            };
+
+            startDateInput.addEventListener('change', () => {
+                applyExecutorAvailability();
+                executorsSelect.dispatchEvent(new Event('change'));
+            });
 
             executorsSelect.addEventListener('change', async () => {
                 const selectedIds = Array.from(executorsSelect.selectedOptions).map(o => o.value).filter(Boolean);
                 if (selectedIds.length === 0) return;
 
                 try {
+                    const startDate = parseDate(startDateInput.value);
+                    const warningMessages = [];
+
+                    if (startDate) {
+                        Array.from(executorsSelect.selectedOptions).forEach(option => {
+                            const unavailableFrom = parseDate(option.dataset.unavailableFrom);
+                            const unavailableTo = parseDate(option.dataset.unavailableTo);
+                            const dismissedFrom = parseDate(option.dataset.dismissedFrom);
+
+                            if (unavailableFrom && unavailableTo && startDate < unavailableFrom) {
+                                warningMessages.push(`Виконавець ${option.text} буде недоступний у період з ${formatUaDate(option.dataset.unavailableFrom)} по ${formatUaDate(option.dataset.unavailableTo)}.`);
+                            }
+
+                            if (dismissedFrom && startDate < dismissedFrom) {
+                                warningMessages.push(`Виконавець ${option.text} буде звільнений з ${formatUaDate(option.dataset.dismissedFrom)}.`);
+                            }
+                        });
+                    }
+
                     const query = selectedIds.map(id => `executorIds=${encodeURIComponent(id)}`).join('&');
                     const response = await fetch(`/ClientTask/InProgressByExecutorIds?${query}`);
                     if (!response.ok) return;
@@ -96,8 +184,12 @@
                     const data = await response.json();
                     if (!Array.isArray(data)) return;
 
+                    const warningsHtml = warningMessages.length > 0
+                        ? `<div class="alert alert-warning">${warningMessages.map(m => `<div>${m}</div>`).join('')}</div>`
+                        : '';
+
                     if (data.length === 0) {
-                        modalContent.innerHTML = '<p class="mb-0">Для обраного виконавця немає активних завдань зі статусом InProgress.</p>';
+                        modalContent.innerHTML = `${warningsHtml}<p class="mb-0">Для обраного виконавця немає активних завдань зі статусом InProgress.</p>`;
                     } else {
                         const rows = data.map(item => `
                             <tr>
@@ -109,6 +201,7 @@
                         `).join('');
 
                         modalContent.innerHTML = `
+                            ${warningsHtml}
                             <div class="table-responsive">
                                 <table class="table table-striped">
                                     <thead>
@@ -130,6 +223,8 @@
                     modal.show();
                 }
             });
+
+            applyExecutorAvailability();
         })();
     </script>
 }

--- a/ClientsApp/Views/Executor/Create.cshtml
+++ b/ClientsApp/Views/Executor/Create.cshtml
@@ -26,6 +26,12 @@
         <span asp-validation-for="Email" class="text-danger"></span>
     </div>
 
+    <div class="mb-3">
+        <label asp-for="DismissedFrom" class="form-label"></label>
+        <input asp-for="DismissedFrom" type="date" class="form-control" min="@today" />
+        <span asp-validation-for="DismissedFrom" class="text-danger"></span>
+    </div>
+
     <div class="row">
         <div class="mb-3 col-md-6">
             <label asp-for="UnavailableFrom" class="form-label"></label>

--- a/ClientsApp/Views/Executor/Delete.cshtml
+++ b/ClientsApp/Views/Executor/Delete.cshtml
@@ -26,6 +26,9 @@
                 @($"{Model.UnavailableFrom:dd.MM.yyyy} - {Model.UnavailableTo:dd.MM.yyyy}")
             }
         </dd>
+
+        <dt class="col-sm-2">Звільнений з дати</dt>
+        <dd class="col-sm-10">@Model.DismissedFrom?.ToString("dd.MM.yyyy")</dd>
     </dl>
 </div>
 

--- a/ClientsApp/Views/Executor/Edit.cshtml
+++ b/ClientsApp/Views/Executor/Edit.cshtml
@@ -28,6 +28,12 @@
         <span asp-validation-for="Email" class="text-danger"></span>
     </div>
 
+    <div class="mb-3">
+        <label asp-for="DismissedFrom" class="form-label"></label>
+        <input asp-for="DismissedFrom" type="date" class="form-control" min="@today" />
+        <span asp-validation-for="DismissedFrom" class="text-danger"></span>
+    </div>
+
     <div class="row">
         <div class="mb-3 col-md-6">
             <label asp-for="UnavailableFrom" class="form-label"></label>

--- a/ClientsApp/Views/Executor/Index.cshtml
+++ b/ClientsApp/Views/Executor/Index.cshtml
@@ -2,6 +2,8 @@
 
 @{
     ViewData["Title"] = "Виконавці";
+    var selectedStatus = ViewData["StatusFilter"]?.ToString() ?? "all";
+    var selectedSort = ViewData["SortOrder"]?.ToString() ?? "id_desc";
 }
 
 <h2>@ViewData["Title"]</h2>
@@ -15,7 +17,22 @@
     <div class="col-md-3">
         <input type="text" name="hourlyRate" value="@ViewData["HourlyRate"]" class="form-control" placeholder="Пошук за ставкою" inputmode="numeric" pattern="[0-9]+" />
     </div>
-    <div class="col-md-5 d-flex align-items-end">
+    <div class="col-md-2">
+        <select name="statusFilter" class="form-select">
+            <option value="all" selected="@(selectedStatus == "all" ? "selected" : null)">Усі</option>
+            <option value="working" selected="@(selectedStatus == "working" ? "selected" : null)">Працює</option>
+            <option value="dismissed" selected="@(selectedStatus == "dismissed" ? "selected" : null)">Звільнений</option>
+        </select>
+    </div>
+    <div class="col-md-3">
+        <select name="sortOrder" class="form-select">
+            <option value="id_desc" selected="@(selectedSort == "id_desc" ? "selected" : null)">Дата внесення (новіші)</option>
+            <option value="id_asc" selected="@(selectedSort == "id_asc" ? "selected" : null)">Дата внесення (старіші)</option>
+            <option value="name_asc" selected="@(selectedSort == "name_asc" ? "selected" : null)">ПІБ ↑</option>
+            <option value="name_desc" selected="@(selectedSort == "name_desc" ? "selected" : null)">ПІБ ↓</option>
+        </select>
+    </div>
+    <div class="col-md-12 d-flex align-items-end">
         <button type="submit" class="btn btn-primary me-2">Пошук</button>
         <a asp-action="Index" class="btn btn-secondary">Скинути</a>
     </div>
@@ -30,6 +47,7 @@
             <th>Ставка/год</th>
             <th>Email</th>
             <th>Недоступний</th>
+            <th>Звільнений з дати</th>
             <th>Дії</th>
         </tr>
     </thead>
@@ -46,6 +64,7 @@
                         @($"{executor.UnavailableFrom:dd.MM.yyyy} - {executor.UnavailableTo:dd.MM.yyyy}")
                     }
                 </td>
+                <td>@executor.DismissedFrom?.ToString("dd.MM.yyyy")</td>
                 <td>
                     <a asp-action="Edit" asp-route-id="@executor.ExecutorId" class="btn btn-primary btn-sm">Редагувати</a>
                     <a asp-action="Delete" asp-route-id="@executor.ExecutorId" class="btn btn-danger btn-sm">Видалити</a>


### PR DESCRIPTION
### Motivation
- Потрібно відстежувати дату звільнення виконавця і дозволити фільтрацію/сортування на сторінці "Виконавці" без великого рефакторингу. 
- Забезпечити, щоб сторінка "Додати завдання" коректно враховувала майбутню недоступність і звільнення, показуючи попередження замість негайного видалення з списку, при цьому зберігаючи серверні перевірки. 

### Description
- Додано нове nullable поле `DismissedFrom` у модель `Executor` з атрибутом `DataType(Date)` і валідацією, що дата не може бути раніше поточного дня (`ClientsApp/Models/Entities/Executor.cs`).
- Додано поле `DismissedFrom` у форми `Create`/`Edit`, відображення в `Index` та `Delete`, та оновлено EF snapshot і створено міграцію `20260417110000_AddExecutorDismissedFrom.cs` для колонки `DismissedFrom`.
- На сторінці `Executor/Index` реалізовано фільтр статусу (`all/working/dismissed`) та сортування через параметр `sortOrder` (ПІБ ↑/↓ і `Id` ↑/↓ як дата внесення), при цьому дефолтне сортування — `id_desc` (`ClientsApp/Controllers/ExecutorController.cs`, `ClientsApp/Views/Executor/Index.cshtml`).
- На сторінці `ClientTask/Create` передано метадані `data-unavailable-from`, `data-unavailable-to`, `data-dismissed-from` для кожного `<option>`, додано клієнтську логіку яка: ховає/блокує виконавців якщо `StartDate >= DismissedFrom` або `StartDate` потрапляє в період `UnavailableFrom..UnavailableTo`, і показує попередження у вже існуючому `inProgressTasksModal` коли `StartDate < UnavailableFrom` або `StartDate < DismissedFrom` (`ClientsApp/Views/ClientTask/Create.cshtml`).
- Додано серверні перевірки у `ClientTaskController.Create (POST)`: валідація вибраних виконавців за `UnavailableFrom/UnavailableTo` і `DismissedFrom` щодо `StartDate`, і винесено логіку підготовки ViewBag у `PopulateCreateViewBagsAsync` для мінімізації змін (`ClientsApp/Controllers/ClientTaskController.cs`).

### Testing
- Запущено проектні команди Git: `git status --short` та підтверджено коміт (hash `dc84be5`).
- Спроба виконати `dotnet ef migrations add AddExecutorDismissedFromToExecutor` не пройшла у середовищі через відсутність `dotnet` CLI, тому міграція була додана вручну; інші автоматизовані тести/збірки не виконувались. 
- Локальні JS-ручні перевірки і серверні сценарії не запускались автоматично у CI в цьому середовищі, але серверна валідація додана для запобігання обходу клієнтської логіки.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e223e040288328bf7aa1a91c311204)