### PR TITLE
Add Executor.DismissedFrom, enforce executor availability on tasks, and improve sorting/filters

### DIFF
--- a/ClientsApp/Controllers/ClientController.cs
+++ b/ClientsApp/Controllers/ClientController.cs
@@ -18,7 +18,7 @@ namespace ClientsApp.Controllers
             _clientService = clientService;
         }
 
-        public async Task<IActionResult> Index(string searchString, string sortOrder)
+        public async Task<IActionResult> Index(string searchString, string? sortBy, string? sortDirection)
         {
             IEnumerable<Client> clients;
             var hasSearch = !string.IsNullOrWhiteSpace(searchString) && searchString.Length >= 3;
@@ -26,14 +26,31 @@ namespace ClientsApp.Controllers
                 ? await _clientService.SearchByNameAsync(searchString)
                 : await _clientService.GetAllAsync();
 
-            var normalizedSortOrder = sortOrder == "desc" ? "desc" : "asc";
-            clients = normalizedSortOrder == "desc"
-                ? clients.OrderByDescending(c => c.ClientId)
-                : clients.OrderBy(c => c.ClientId);
+            var normalizedSortBy = string.IsNullOrWhiteSpace(sortBy) ? "id" : sortBy.ToLowerInvariant();
+            if (normalizedSortBy != "name" && normalizedSortBy != "id")
+            {
+                normalizedSortBy = "id";
+            }
+
+            var normalizedSortDirection = string.IsNullOrWhiteSpace(sortDirection)
+                ? "asc"
+                : sortDirection.ToLowerInvariant();
+            if (normalizedSortDirection != "asc" && normalizedSortDirection != "desc")
+            {
+                normalizedSortDirection = "asc";
+            }
+
+            clients = normalizedSortBy switch
+            {
+                "name" when normalizedSortDirection == "desc" => clients.OrderByDescending(c => c.Name),
+                "name" => clients.OrderBy(c => c.Name),
+                "id" when normalizedSortDirection == "desc" => clients.OrderByDescending(c => c.ClientId),
+                _ => clients.OrderBy(c => c.ClientId)
+            };
 
             ViewData["SearchString"] = searchString;
-            ViewData["SortOrder"] = normalizedSortOrder;
-            ViewData["NextSortOrder"] = normalizedSortOrder == "asc" ? "desc" : "asc";
+            ViewData["SortBy"] = normalizedSortBy;
+            ViewData["SortDirection"] = normalizedSortDirection;
             return View(clients);
         }
 

--- a/ClientsApp/Controllers/ClientTaskController.cs
+++ b/ClientsApp/Controllers/ClientTaskController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using ClientsApp.Models.Entities;
 using ClientsApp.Models.ViewModels;
 using ClientsApp.BLL.Interfaces;
+using System.Collections.Generic;
 
 namespace ClientsApp.Controllers
 {
@@ -68,12 +69,7 @@ namespace ClientsApp.Controllers
         [Authorize(Roles = "Manager")]
         public async Task<IActionResult> Create()
         {
-            ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name");
-            var availableExecutors = (await _executorService.GetAllAsync())
-                .Where(e => !e.UnavailableFrom.HasValue && !e.UnavailableTo.HasValue)
-                .ToList();
-            ViewBag.Executors = new MultiSelectList(availableExecutors, "ExecutorId", "FullName");
-            ViewBag.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)));
+            await PopulateCreateViewBagsAsync();
             return View();
         }
 
@@ -84,12 +80,41 @@ namespace ClientsApp.Controllers
         {
             if (!ModelState.IsValid)
             {
-                ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", task.ClientId);
-                var availableExecutors = (await _executorService.GetAllAsync())
-                    .Where(e => !e.UnavailableFrom.HasValue && !e.UnavailableTo.HasValue)
-                    .ToList();
-                ViewBag.Executors = new MultiSelectList(availableExecutors, "ExecutorId", "FullName", selectedExecutors);
-                ViewBag.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), task.TaskStatus);
+                await PopulateCreateViewBagsAsync(task, selectedExecutors);
+                return View(task);
+            }
+
+            var startDate = task.StartDate.Date;
+            var selectedExecutorsData = (await _executorService.GetAllAsync())
+                .Where(e => selectedExecutors.Contains(e.ExecutorId))
+                .ToList();
+
+            var invalidUnavailableExecutors = selectedExecutorsData
+                .Where(e => e.UnavailableFrom.HasValue
+                    && e.UnavailableTo.HasValue
+                    && startDate >= e.UnavailableFrom.Value.Date
+                    && startDate <= e.UnavailableTo.Value.Date)
+                .Select(e => e.FullName)
+                .ToList();
+
+            if (invalidUnavailableExecutors.Count > 0)
+            {
+                ModelState.AddModelError(string.Empty, $"Обрані виконавці недоступні на дату початку: {string.Join(", ", invalidUnavailableExecutors)}.");
+            }
+
+            var dismissedExecutors = selectedExecutorsData
+                .Where(e => e.DismissedFrom.HasValue && startDate >= e.DismissedFrom.Value.Date)
+                .Select(e => e.FullName)
+                .ToList();
+
+            if (dismissedExecutors.Count > 0)
+            {
+                ModelState.AddModelError(string.Empty, $"Обрані виконавці звільнені на дату початку: {string.Join(", ", dismissedExecutors)}.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                await PopulateCreateViewBagsAsync(task, selectedExecutors);
                 return View(task);
             }
 
@@ -203,6 +228,19 @@ namespace ClientsApp.Controllers
         {
             await _taskService.DeleteAsync(id);
             return RedirectToAction(nameof(Index));
+        }
+
+        private async Task PopulateCreateViewBagsAsync(ClientTask? task = null, int[]? selectedExecutors = null)
+        {
+            var today = DateTime.Today;
+
+            ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", task?.ClientId);
+            ViewBag.Executors = (await _executorService.GetAllAsync())
+                .Where(e => !e.DismissedFrom.HasValue || e.DismissedFrom.Value.Date >= today)
+                .OrderBy(e => e.FullName)
+                .ToList();
+            ViewBag.SelectedExecutors = new HashSet<int>(selectedExecutors ?? Array.Empty<int>());
+            ViewBag.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), task?.TaskStatus);
         }
     }
 }

--- a/ClientsApp/Controllers/ExecutorController.cs
+++ b/ClientsApp/Controllers/ExecutorController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace ClientsApp.Controllers
@@ -18,17 +19,56 @@ namespace ClientsApp.Controllers
             _executorService = executorService;
         }
 
-        public async Task<IActionResult> Index(string? fullName, decimal? hourlyRate)
+        public async Task<IActionResult> Index(
+            string? fullName,
+            decimal? hourlyRate,
+            string? statusFilter,
+            string? sortBy,
+            string? sortDirection)
         {
             var hasFilters = !string.IsNullOrWhiteSpace(fullName) || hourlyRate.HasValue;
             var executors = hasFilters
                 ? await _executorService.SearchAsync(fullName, hourlyRate)
                 : await _executorService.GetAllAsync();
 
+            var today = DateTime.Today;
+            var normalizedStatus = string.IsNullOrWhiteSpace(statusFilter) ? "all" : statusFilter.ToLowerInvariant();
+            executors = normalizedStatus switch
+            {
+                "working" => executors.Where(e => !e.DismissedFrom.HasValue || e.DismissedFrom.Value.Date > today),
+                "dismissed" => executors.Where(e => e.DismissedFrom.HasValue && e.DismissedFrom.Value.Date <= today),
+                _ => executors
+            };
+
+            var normalizedSortBy = string.IsNullOrWhiteSpace(sortBy) ? "id" : sortBy.ToLowerInvariant();
+            if (normalizedSortBy != "name" && normalizedSortBy != "id")
+            {
+                normalizedSortBy = "id";
+            }
+
+            var normalizedSortDirection = string.IsNullOrWhiteSpace(sortDirection)
+                ? "desc"
+                : sortDirection.ToLowerInvariant();
+            if (normalizedSortDirection != "asc" && normalizedSortDirection != "desc")
+            {
+                normalizedSortDirection = normalizedSortBy == "name" ? "asc" : "desc";
+            }
+
+            executors = normalizedSortBy switch
+            {
+                "name" when normalizedSortDirection == "desc" => executors.OrderByDescending(e => e.FullName),
+                "name" => executors.OrderBy(e => e.FullName),
+                "id" when normalizedSortDirection == "asc" => executors.OrderBy(e => e.ExecutorId),
+                _ => executors.OrderByDescending(e => e.ExecutorId)
+            };
+
             ViewData["FullName"] = fullName;
             ViewData["HourlyRate"] = hourlyRate.HasValue
                 ? hourlyRate.Value.ToString(CultureInfo.InvariantCulture)
                 : null;
+            ViewData["StatusFilter"] = normalizedStatus;
+            ViewData["SortBy"] = normalizedSortBy;
+            ViewData["SortDirection"] = normalizedSortDirection;
 
             return View(executors);
         }
@@ -99,6 +139,11 @@ namespace ClientsApp.Controllers
                 && executor.UnavailableTo.Value.Date < executor.UnavailableFrom.Value.Date)
             {
                 ModelState.AddModelError(nameof(Executor.UnavailableTo), "Дата \"Недоступний до\" не може бути раніше дати \"Недоступний з\".");
+            }
+
+            if (executor.DismissedFrom.HasValue && executor.DismissedFrom.Value.Date < today)
+            {
+                ModelState.AddModelError(nameof(Executor.DismissedFrom), "Дата \"Звільнений з дати\" не може бути раніше поточної дати.");
             }
         }
     }

--- a/ClientsApp/Migrations/20260417110000_AddExecutorDismissedFrom.cs
+++ b/ClientsApp/Migrations/20260417110000_AddExecutorDismissedFrom.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ClientsApp.Migrations
+{
+    public partial class AddExecutorDismissedFrom : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DismissedFrom",
+                table: "Executors",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DismissedFrom",
+                table: "Executors");
+        }
+    }
+}

--- a/ClientsApp/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/ClientsApp/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -104,6 +104,9 @@ namespace ClientsApp.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ExecutorId"));
 
+                    b.Property<DateTime?>("DismissedFrom")
+                        .HasColumnType("datetime2");
+
                     b.Property<string>("Email")
                         .HasColumnType("nvarchar(max)");
 

--- a/ClientsApp/Models/Entities/Executor.cs
+++ b/ClientsApp/Models/Entities/Executor.cs
@@ -33,6 +33,10 @@ namespace ClientsApp.Models.Entities
         [Display(Name = "Недоступний до")]
         public DateTime? UnavailableTo { get; set; }
 
+        [DataType(DataType.Date)]
+        [Display(Name = "Звільнений з дати")]
+        public DateTime? DismissedFrom { get; set; }
+
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             var today = DateTime.Today;
@@ -51,6 +55,13 @@ namespace ClientsApp.Models.Entities
                 yield return new ValidationResult(
                     "Дата \"Недоступний до\" не може бути раніше дати \"Недоступний з\".",
                     new[] { nameof(UnavailableTo) });
+            }
+
+            if (DismissedFrom.HasValue && DismissedFrom.Value.Date < today)
+            {
+                yield return new ValidationResult(
+                    "Дата \"Звільнений з дати\" не може бути раніше поточної дати.",
+                    new[] { nameof(DismissedFrom) });
             }
         }
         public ICollection<ExecutorTask>? ExecutorTasks { get; set; }

--- a/ClientsApp/Program.cs
+++ b/ClientsApp/Program.cs
@@ -202,6 +202,11 @@ BEGIN
     ALTER TABLE [AspNetUsers] ADD [ExecutorId] int NULL;
 END;
 
+IF COL_LENGTH('Executors', 'DismissedFrom') IS NULL
+BEGIN
+    ALTER TABLE [Executors] ADD [DismissedFrom] datetime2 NULL;
+END;
+
 IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = 'FK_AspNetUsers_Executors_ExecutorId')
 BEGIN
     ALTER TABLE [AspNetUsers] ADD CONSTRAINT [FK_AspNetUsers_Executors_ExecutorId]

--- a/ClientsApp/Views/Client/Index.cshtml
+++ b/ClientsApp/Views/Client/Index.cshtml
@@ -3,6 +3,10 @@
 @{
     ViewData["Title"] = "Клієнти";
     Layout = "_Layout";
+    var currentSortBy = ViewData["SortBy"]?.ToString() ?? "id";
+    var currentSortDirection = ViewData["SortDirection"]?.ToString() ?? "asc";
+    var nextIdDirection = currentSortBy == "id" && currentSortDirection == "asc" ? "desc" : "asc";
+    var nextNameDirection = currentSortBy == "name" && currentSortDirection == "asc" ? "desc" : "asc";
 }
 <h2>@ViewData["Title"]</h2>
 
@@ -14,6 +18,8 @@
 </p>
 
 <form method="get" class="row g-3 mb-3">
+    <input type="hidden" name="sortBy" value="@currentSortBy" />
+    <input type="hidden" name="sortDirection" value="@currentSortDirection" />
     <div class="col-md-4">
         <input type="text" name="searchString" value="@ViewData["SearchString"]" class="form-control" placeholder="Пошук за ім'ям" minlength="3" />
     </div>
@@ -21,16 +27,32 @@
         <button type="submit" class="btn btn-primary me-2">Пошук</button>
         <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути</a>
     </div>
-    <div class="col-md-4 d-flex align-items-end justify-content-md-end">
-        <a asp-action="Index"
-           asp-route-searchString="@ViewData["SearchString"]"
-           asp-route-sortOrder="@ViewData["NextSortOrder"]"
-           class="btn btn-outline-primary flex-fill flex-md-grow-0 ms-md-auto">
-            Сортувати за датою додавання
-            <span class="ms-1">@((ViewData["SortOrder"] as string) == "asc" ? "↑" : "↓")</span>
-        </a>
-    </div>
 </form>
+
+<div class="mb-3 d-flex gap-2">
+    <a asp-action="Index"
+       asp-route-searchString="@ViewData["SearchString"]"
+       asp-route-sortBy="id"
+       asp-route-sortDirection="@nextIdDirection"
+       class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
+        Сортувати за датою додавання
+        @if (currentSortBy == "id")
+        {
+            <span>@(currentSortDirection == "asc" ? "↑" : "↓")</span>
+        }
+    </a>
+    <a asp-action="Index"
+       asp-route-searchString="@ViewData["SearchString"]"
+       asp-route-sortBy="name"
+       asp-route-sortDirection="@nextNameDirection"
+       class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">
+        Сортувати за назвою
+        @if (currentSortBy == "name")
+        {
+            <span>@(currentSortDirection == "asc" ? "↑" : "↓")</span>
+        }
+    </a>
+</div>
 
 <table class="table table-striped">
     <thead>

--- a/ClientsApp/Views/ClientTask/Create.cshtml
+++ b/ClientsApp/Views/ClientTask/Create.cshtml
@@ -3,6 +3,8 @@
 @{
     ViewData["Title"] = "Додати завдання";
     Layout = "_Layout";
+    var executors = ViewBag.Executors as IEnumerable<ClientsApp.Models.Entities.Executor> ?? new List<ClientsApp.Models.Entities.Executor>();
+    var selectedExecutors = ViewBag.SelectedExecutors as HashSet<int> ?? new HashSet<int>();
 }
 
 <h2>Додати завдання</h2>
@@ -42,7 +44,33 @@
 
     <div class="form-group">
         <label>Виконавці</label>
-        <select id="selectedExecutors" name="selectedExecutors" class="form-control" multiple asp-items="ViewBag.Executors"></select>
+        <select id="selectedExecutors" name="selectedExecutors" class="form-control" multiple>
+            @foreach (var executor in executors)
+            {
+                var unavailableFrom = executor.UnavailableFrom?.ToString("yyyy-MM-dd");
+                var unavailableTo = executor.UnavailableTo?.ToString("yyyy-MM-dd");
+                var dismissedFrom = executor.DismissedFrom?.ToString("yyyy-MM-dd");
+                if (selectedExecutors.Contains(executor.ExecutorId))
+                {
+                    <option value="@executor.ExecutorId"
+                            selected="selected"
+                            data-unavailable-from="@unavailableFrom"
+                            data-unavailable-to="@unavailableTo"
+                            data-dismissed-from="@dismissedFrom">
+                        @executor.FullName
+                    </option>
+                }
+                else
+                {
+                    <option value="@executor.ExecutorId"
+                            data-unavailable-from="@unavailableFrom"
+                            data-unavailable-to="@unavailableTo"
+                            data-dismissed-from="@dismissedFrom">
+                        @executor.FullName
+                    </option>
+                }
+            }
+        </select>
     </div>
 
     <div class="form-group">
@@ -78,17 +106,77 @@
     <script>
         (function () {
             const executorsSelect = document.getElementById('selectedExecutors');
+            const startDateInput = document.getElementById('StartDate');
             const modalElement = document.getElementById('inProgressTasksModal');
             const modalContent = document.getElementById('inProgressTasksContent');
-            if (!executorsSelect || !modalElement || !modalContent || !window.bootstrap) return;
+            if (!executorsSelect || !startDateInput || !modalElement || !modalContent || !window.bootstrap) return;
 
             const modal = new bootstrap.Modal(modalElement);
+            const parseDate = (value) => value ? new Date(`${value}T00:00:00`) : null;
+
+            const formatUaDate = (value) => {
+                const date = parseDate(value);
+                if (!date || Number.isNaN(date.getTime())) return '';
+                const day = String(date.getDate()).padStart(2, '0');
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                return `${day}.${month}.${date.getFullYear()}`;
+            };
+
+            const applyExecutorAvailability = () => {
+                const startDate = parseDate(startDateInput.value);
+                const options = Array.from(executorsSelect.options);
+                options.forEach(option => {
+                    const dismissedFrom = parseDate(option.dataset.dismissedFrom);
+                    const unavailableFrom = parseDate(option.dataset.unavailableFrom);
+                    const unavailableTo = parseDate(option.dataset.unavailableTo);
+
+                    let allowed = true;
+
+                    if (startDate && dismissedFrom && startDate >= dismissedFrom) {
+                        allowed = false;
+                    }
+
+                    if (startDate && unavailableFrom && unavailableTo && startDate >= unavailableFrom && startDate <= unavailableTo) {
+                        allowed = false;
+                    }
+
+                    option.hidden = !allowed;
+                    option.disabled = !allowed;
+                    if (!allowed) {
+                        option.selected = false;
+                    }
+                });
+            };
+
+            startDateInput.addEventListener('change', () => {
+                applyExecutorAvailability();
+                executorsSelect.dispatchEvent(new Event('change'));
+            });
 
             executorsSelect.addEventListener('change', async () => {
                 const selectedIds = Array.from(executorsSelect.selectedOptions).map(o => o.value).filter(Boolean);
                 if (selectedIds.length === 0) return;
 
                 try {
+                    const startDate = parseDate(startDateInput.value);
+                    const warningMessages = [];
+
+                    if (startDate) {
+                        Array.from(executorsSelect.selectedOptions).forEach(option => {
+                            const unavailableFrom = parseDate(option.dataset.unavailableFrom);
+                            const unavailableTo = parseDate(option.dataset.unavailableTo);
+                            const dismissedFrom = parseDate(option.dataset.dismissedFrom);
+
+                            if (unavailableFrom && unavailableTo && startDate < unavailableFrom) {
+                                warningMessages.push(`Виконавець ${option.text} буде недоступний у період з ${formatUaDate(option.dataset.unavailableFrom)} по ${formatUaDate(option.dataset.unavailableTo)}.`);
+                            }
+
+                            if (dismissedFrom && startDate < dismissedFrom) {
+                                warningMessages.push(`Виконавець ${option.text} буде звільнений з ${formatUaDate(option.dataset.dismissedFrom)}.`);
+                            }
+                        });
+                    }
+
                     const query = selectedIds.map(id => `executorIds=${encodeURIComponent(id)}`).join('&');
                     const response = await fetch(`/ClientTask/InProgressByExecutorIds?${query}`);
                     if (!response.ok) return;
@@ -96,8 +184,12 @@
                     const data = await response.json();
                     if (!Array.isArray(data)) return;
 
+                    const warningsHtml = warningMessages.length > 0
+                        ? `<div class="alert alert-warning">${warningMessages.map(m => `<div>${m}</div>`).join('')}</div>`
+                        : '';
+
                     if (data.length === 0) {
-                        modalContent.innerHTML = '<p class="mb-0">Для обраного виконавця немає активних завдань зі статусом InProgress.</p>';
+                        modalContent.innerHTML = `${warningsHtml}<p class="mb-0">Для обраного виконавця немає активних завдань зі статусом InProgress.</p>`;
                     } else {
                         const rows = data.map(item => `
                             <tr>
@@ -109,6 +201,7 @@
                         `).join('');
 
                         modalContent.innerHTML = `
+                            ${warningsHtml}
                             <div class="table-responsive">
                                 <table class="table table-striped">
                                     <thead>
@@ -130,6 +223,8 @@
                     modal.show();
                 }
             });
+
+            applyExecutorAvailability();
         })();
     </script>
 }

--- a/ClientsApp/Views/Executor/Create.cshtml
+++ b/ClientsApp/Views/Executor/Create.cshtml
@@ -26,6 +26,12 @@
         <span asp-validation-for="Email" class="text-danger"></span>
     </div>
 
+    <div class="mb-3">
+        <label asp-for="DismissedFrom" class="form-label"></label>
+        <input asp-for="DismissedFrom" type="date" class="form-control" min="@today" />
+        <span asp-validation-for="DismissedFrom" class="text-danger"></span>
+    </div>
+
     <div class="row">
         <div class="mb-3 col-md-6">
             <label asp-for="UnavailableFrom" class="form-label"></label>

--- a/ClientsApp/Views/Executor/Delete.cshtml
+++ b/ClientsApp/Views/Executor/Delete.cshtml
@@ -26,6 +26,9 @@
                 @($"{Model.UnavailableFrom:dd.MM.yyyy} - {Model.UnavailableTo:dd.MM.yyyy}")
             }
         </dd>
+
+        <dt class="col-sm-2">Звільнений з дати</dt>
+        <dd class="col-sm-10">@Model.DismissedFrom?.ToString("dd.MM.yyyy")</dd>
     </dl>
 </div>
 

--- a/ClientsApp/Views/Executor/Edit.cshtml
+++ b/ClientsApp/Views/Executor/Edit.cshtml
@@ -28,6 +28,12 @@
         <span asp-validation-for="Email" class="text-danger"></span>
     </div>
 
+    <div class="mb-3">
+        <label asp-for="DismissedFrom" class="form-label"></label>
+        <input asp-for="DismissedFrom" type="date" class="form-control" min="@today" />
+        <span asp-validation-for="DismissedFrom" class="text-danger"></span>
+    </div>
+
     <div class="row">
         <div class="mb-3 col-md-6">
             <label asp-for="UnavailableFrom" class="form-label"></label>

--- a/ClientsApp/Views/Executor/Index.cshtml
+++ b/ClientsApp/Views/Executor/Index.cshtml
@@ -2,6 +2,11 @@
 
 @{
     ViewData["Title"] = "Виконавці";
+    var selectedStatus = ViewData["StatusFilter"]?.ToString() ?? "all";
+    var currentSortBy = ViewData["SortBy"]?.ToString() ?? "id";
+    var currentSortDirection = ViewData["SortDirection"]?.ToString() ?? "desc";
+    var nextNameDirection = currentSortBy == "name" && currentSortDirection == "asc" ? "desc" : "asc";
+    var nextIdDirection = currentSortBy == "id" && currentSortDirection == "desc" ? "asc" : "desc";
 }
 
 <h2>@ViewData["Title"]</h2>
@@ -9,17 +14,55 @@
 <p>На цій сторінці Виконавці Ви можете отримати усю інформацію по усіх виконавцях фірми,  а також додавати інформацію, редагувати та видаляти її. </p>
 
 <form method="get" class="row g-3 mb-3">
+    <input type="hidden" name="sortBy" value="@currentSortBy" />
+    <input type="hidden" name="sortDirection" value="@currentSortDirection" />
     <div class="col-md-4">
         <input type="text" name="fullName" value="@ViewData["FullName"]" class="form-control" placeholder="Пошук за ПІБ" />
     </div>
     <div class="col-md-3">
         <input type="text" name="hourlyRate" value="@ViewData["HourlyRate"]" class="form-control" placeholder="Пошук за ставкою" inputmode="numeric" pattern="[0-9]+" />
     </div>
-    <div class="col-md-5 d-flex align-items-end">
+    <div class="col-md-2">
+        <select name="statusFilter" class="form-select">
+            <option value="all" selected="@(selectedStatus == "all" ? "selected" : null)">Усі</option>
+            <option value="working" selected="@(selectedStatus == "working" ? "selected" : null)">Працює</option>
+            <option value="dismissed" selected="@(selectedStatus == "dismissed" ? "selected" : null)">Звільнений</option>
+        </select>
+    </div>
+    <div class="col-md-3 d-flex align-items-end">
         <button type="submit" class="btn btn-primary me-2">Пошук</button>
         <a asp-action="Index" class="btn btn-secondary">Скинути</a>
     </div>
 </form>
+
+<div class="mb-3 d-flex gap-2">
+    <a asp-action="Index"
+       asp-route-fullName="@ViewData["FullName"]"
+       asp-route-hourlyRate="@ViewData["HourlyRate"]"
+       asp-route-statusFilter="@selectedStatus"
+       asp-route-sortBy="name"
+       asp-route-sortDirection="@nextNameDirection"
+       class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">
+        Сортувати за ПІБ
+        @if (currentSortBy == "name")
+        {
+            <span>@(currentSortDirection == "asc" ? "↑" : "↓")</span>
+        }
+    </a>
+    <a asp-action="Index"
+       asp-route-fullName="@ViewData["FullName"]"
+       asp-route-hourlyRate="@ViewData["HourlyRate"]"
+       asp-route-statusFilter="@selectedStatus"
+       asp-route-sortBy="id"
+       asp-route-sortDirection="@nextIdDirection"
+       class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
+        Сортувати за датою внесення
+        @if (currentSortBy == "id")
+        {
+            <span>@(currentSortDirection == "desc" ? "↓" : "↑")</span>
+        }
+    </a>
+</div>
 
 <a asp-action="Create" class="btn btn-success mb-2">Додати Виконавця</a>
 
@@ -30,6 +73,7 @@
             <th>Ставка/год</th>
             <th>Email</th>
             <th>Недоступний</th>
+            <th>Звільнений з дати</th>
             <th>Дії</th>
         </tr>
     </thead>
@@ -46,6 +90,7 @@
                         @($"{executor.UnavailableFrom:dd.MM.yyyy} - {executor.UnavailableTo:dd.MM.yyyy}")
                     }
                 </td>
+                <td>@executor.DismissedFrom?.ToString("dd.MM.yyyy")</td>
                 <td>
                     <a asp-action="Edit" asp-route-id="@executor.ExecutorId" class="btn btn-primary btn-sm">Редагувати</a>
                     <a asp-action="Delete" asp-route-id="@executor.ExecutorId" class="btn btn-danger btn-sm">Видалити</a>


### PR DESCRIPTION
### Motivation

- Introduce a dismissal date for executors so they can be marked as unavailable for future tasks.
- Prevent assigning tasks to executors who are unavailable or dismissed at the task start date and surface warnings to the user.
- Improve sorting and filtering UX for clients and executors by supporting `sortBy`/`sortDirection` and status filters.

### Description

- Added a nullable `DismissedFrom` property to `ClientsApp.Models.Entities.Executor`, with validation to prevent past dismissal dates and updated the entity snapshot and SQL seed (`Program.cs`) to add the `DismissedFrom` column.
- Added a new EF migration `20260417110000_AddExecutorDismissedFrom` to add the `DismissedFrom` column to the `Executors` table.
- Updated `ExecutorController.Index` to support `statusFilter`, `sortBy`, and `sortDirection`, to filter by working/dismissed status and apply stable sorting, and added server-side validation for `DismissedFrom` in `ValidateUnavailablePeriod`.
- Updated client and executor listing views (`Client/Index`, `Executor/Index`) to wire the new sort parameters and render sort buttons and status filter, and updated executor views (`Create`, `Edit`, `Delete`, `Index`) to include and display the `DismissedFrom` field.
- Refactored `ClientTaskController` to centralize viewbag population in `PopulateCreateViewBagsAsync`, added server-side checks in the `Create` action to reject selected executors who are unavailable or dismissed at the task `StartDate`, and preserved existing logic for creating `ExecutorTask` entries.
- Enhanced `ClientTask/Create` view: include executor dataset attributes (`data-unavailable-from`, `data-unavailable-to`, `data-dismissed-from`), client-side logic to hide/disable executors based on `StartDate`, display warnings about availability/dismissal, and show current `InProgress` tasks via the existing `InProgressByExecutorIds` endpoint.

### Testing

- No automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e223e040288328bf7aa1a91c311204)