### PR TITLE
Redesign home and shell UI into modern SaaS dashboard

### DIFF
--- a/ClientsApp/Views/Home/Index.cshtml
+++ b/ClientsApp/Views/Home/Index.cshtml
@@ -2,15 +2,118 @@
     ViewData["Title"] = "Головна сторінка";
 }
 
-<div class="text-center my-5">
-    <h1 class="display-4">Вітаємо в системі обліку клієнтів ClientsApp!</h1>
-    <p class="lead">Цей застосунок допомагає керувати клієнтами, завданнями, робочим часом та оплатами.</p>
-</div>
+<section class="home-hero text-center">
+    <h1 class="home-hero-title">Вітаємо в системі обліку клієнтів ClientsApp!</h1>
+    <p class="home-hero-subtitle">Цей застосунок допомагає керувати клієнтами, завданнями, робочим часом та оплатами.</p>
+</section>
 
-<div class="home-links">
-    <p><a href="@Url.Action("Index", "Client")">Клієнти</a>Керуйте інформацією про клієнтів.</p>
-    <p><a href="@Url.Action("Index", "Executor")">Виконавці</a>Додавайте та редагуйте виконавців.</p>
-    <p><a href="@Url.Action("Index", "ClientTask")">Завдання</a>Створюйте та відстежуйте завдання клієнтів.</p>
-    <p><a href="@Url.Action("Index", "ExecutorTask")">Облік робочого часу</a>Фіксуйте витрати часу виконавців.</p>
-    <p><a href="@Url.Action("Index", "Payment")">Оплати</a>Переглядайте та додавайте платежі.</p>
-</div>
+<section class="home-cards" aria-label="Основні розділи ClientsApp">
+    <a class="dashboard-card" href="@Url.Action("Index", "Client")" aria-label="Перейти до розділу Клієнти">
+        <span class="card-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17 21V19C17 16.7909 15.2091 15 13 15H7C4.79086 15 3 16.7909 3 19V21" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                <circle cx="10" cy="7" r="4" stroke="currentColor" stroke-width="1.8"/>
+                <path d="M21 21V19C20.9986 17.1553 19.7322 15.5518 17.94 15.123" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                <path d="M14 3.13C15.7961 3.58946 17.0553 5.19406 17.0553 7.05C17.0553 8.90594 15.7961 10.5105 14 10.97" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </span>
+        <span class="card-content">
+            <span class="card-title">Клієнти</span>
+            <span class="card-description">Керуйте інформацією про клієнтів.</span>
+        </span>
+    </a>
+
+    <a class="dashboard-card" href="@Url.Action("Index", "Executor")" aria-label="Перейти до розділу Виконавці">
+        <span class="card-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" stroke="currentColor" stroke-width="1.8"/>
+                <path d="M4 22C4 18.6863 7.58172 16 12 16C16.4183 16 20 18.6863 20 22" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                <path d="M19 9L21 11L23 8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </span>
+        <span class="card-content">
+            <span class="card-title">Виконавці</span>
+            <span class="card-description">Додавайте та редагуйте виконавців.</span>
+        </span>
+    </a>
+
+    <a class="dashboard-card" href="@Url.Action("Index", "ClientTask")" aria-label="Перейти до розділу Завдання">
+        <span class="card-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect x="3" y="4" width="18" height="17" rx="2" stroke="currentColor" stroke-width="1.8"/>
+                <path d="M8 2V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                <path d="M16 2V6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                <path d="M3 9H21" stroke="currentColor" stroke-width="1.8"/>
+                <path d="M8 14H12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                <path d="M8 18H16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+        </span>
+        <span class="card-content">
+            <span class="card-title">Завдання</span>
+            <span class="card-description">Створюйте та відстежуйте завдання клієнтів.</span>
+        </span>
+    </a>
+
+    <a class="dashboard-card" href="@Url.Action("Index", "ExecutorTask")" aria-label="Перейти до розділу Облік робочого часу">
+        <span class="card-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.8"/>
+                <path d="M12 7V12L15 15" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                <path d="M7 3L5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                <path d="M17 3L19 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+        </span>
+        <span class="card-content">
+            <span class="card-title">Облік робочого часу</span>
+            <span class="card-description">Фіксуйте витрати часу виконавців.</span>
+        </span>
+    </a>
+
+    <a class="dashboard-card" href="@Url.Action("Index", "Payment")" aria-label="Перейти до розділу Оплати">
+        <span class="card-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect x="2.5" y="5" width="19" height="14" rx="3" stroke="currentColor" stroke-width="1.8"/>
+                <path d="M2.5 10H21.5" stroke="currentColor" stroke-width="1.8"/>
+                <path d="M7 15H11" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                <circle cx="17" cy="15" r="1" fill="currentColor"/>
+            </svg>
+        </span>
+        <span class="card-content">
+            <span class="card-title">Оплати</span>
+            <span class="card-description">Переглядайте та додавайте платежі.</span>
+        </span>
+    </a>
+
+    <a class="dashboard-card" href="@Url.Action("Index", "Statistics")" aria-label="Перейти до розділу Статистики та звіти">
+        <span class="card-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M4 19H20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                <rect x="5" y="11" width="3" height="6" rx="1" stroke="currentColor" stroke-width="1.8"/>
+                <rect x="10.5" y="8" width="3" height="9" rx="1" stroke="currentColor" stroke-width="1.8"/>
+                <rect x="16" y="5" width="3" height="12" rx="1" stroke="currentColor" stroke-width="1.8"/>
+            </svg>
+        </span>
+        <span class="card-content">
+            <span class="card-title">Статистики та звіти</span>
+            <span class="card-description">Аналізуйте ключові показники та результати.</span>
+        </span>
+    </a>
+
+    @if (User.Identity?.IsAuthenticated == true && User.IsInRole("Manager"))
+    {
+        <a class="dashboard-card" href="@Url.Action("Register", "Account")" aria-label="Перейти до розділу Створити користувача">
+            <span class="card-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="9" cy="8" r="4" stroke="currentColor" stroke-width="1.8"/>
+                    <path d="M2.5 21C2.5 17.6863 5.41015 15 9 15C12.5899 15 15.5 17.6863 15.5 21" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                    <path d="M19 8V14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                    <path d="M16 11H22" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                </svg>
+            </span>
+            <span class="card-content">
+                <span class="card-title">Створити користувача</span>
+                <span class="card-description">Додайте нового користувача з відповідною роллю доступу.</span>
+            </span>
+        </a>
+    }
+</section>

--- a/ClientsApp/Views/Shared/_Layout.cshtml
+++ b/ClientsApp/Views/Shared/_Layout.cshtml
@@ -1,84 +1,90 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="uk">
 <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - ClientsApp</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </head>
-<body class="d-flex flex-column min-vh-100">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
-        <div class="container">
-            <a class="navbar-brand fs-2 fw-bold" asp-area="" asp-controller="Home" asp-action="Index">ClientsApp</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Перемкнути навігацію">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarNav">
-                @if (User.Identity?.IsAuthenticated == true)
-                {
-                    <ul class="navbar-nav me-auto">
-                        <li class="nav-item">
-                            <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Client" ? "active" : "")" asp-controller="Client" asp-action="Index">Клієнти</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Executor" ? "active" : "")" asp-controller="Executor" asp-action="Index">Виконавці</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ClientTask" ? "active" : "")" asp-controller="ClientTask" asp-action="Index">Завдання</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ExecutorTask" ? "active" : "")" asp-controller="ExecutorTask" asp-action="Index">Облік робочого часу</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Payment" ? "active" : "")" asp-controller="Payment" asp-action="Index">Оплати</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Statistics" ? "active" : "")" asp-controller="Statistics" asp-action="Index">Статистики та звіти</a>
-                        </li>
-                        @if (User.IsInRole("Manager"))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Account" && ViewContext.RouteData.Values["action"]?.ToString() == "Register" ? "active" : "")" asp-controller="Account" asp-action="Register">Створити користувача</a>
-                            </li>
-                        }
-                    </ul>
+<body class="app-shell d-flex flex-column min-vh-100">
+    <header class="app-header">
+        <nav class="navbar navbar-expand-xl app-navbar">
+            <div class="container app-navbar-container">
+                <a class="navbar-brand app-brand" asp-area="" asp-controller="Home" asp-action="Index">ClientsApp</a>
 
-                    <ul class="navbar-nav ms-auto">
-                        <li class="nav-item me-2 align-self-center">
+                <button class="navbar-toggler app-navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Перемкнути навігацію">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+
+                <div class="collapse navbar-collapse" id="navbarNav">
+                    @if (User.Identity?.IsAuthenticated == true)
+                    {
+                        <ul class="navbar-nav app-nav-center">
+                            <li class="nav-item">
+                                <a class="nav-link app-nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Client" ? "active" : "")" asp-controller="Client" asp-action="Index">Клієнти</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link app-nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Executor" ? "active" : "")" asp-controller="Executor" asp-action="Index">Виконавці</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link app-nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ClientTask" ? "active" : "")" asp-controller="ClientTask" asp-action="Index">Завдання</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link app-nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "ExecutorTask" ? "active" : "")" asp-controller="ExecutorTask" asp-action="Index">Облік робочого часу</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link app-nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Payment" ? "active" : "")" asp-controller="Payment" asp-action="Index">Оплати</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link app-nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Statistics" ? "active" : "")" asp-controller="Statistics" asp-action="Index">Статистики та звіти</a>
+                            </li>
                             @if (User.IsInRole("Manager"))
                             {
-                                <a class="nav-link" asp-controller="Account" asp-action="Profile">@User.Identity.Name</a>
+                                <li class="nav-item">
+                                    <a class="nav-link app-nav-link @(ViewContext.RouteData.Values["controller"]?.ToString() == "Account" && ViewContext.RouteData.Values["action"]?.ToString() == "Register" ? "active" : "")" asp-controller="Account" asp-action="Register">Створити користувача</a>
+                                </li>
+                            }
+                        </ul>
+
+                        <div class="app-nav-right">
+                            @if (User.IsInRole("Manager"))
+                            {
+                                <a class="app-user-link" asp-controller="Account" asp-action="Profile">@User.Identity?.Name</a>
                             }
                             else
                             {
-                                <span class="nav-link text-muted">@User.Identity.Name</span>
+                                <span class="app-user-email">@User.Identity?.Name</span>
                             }
-                        </li>
-                        <li class="nav-item">
-                            <form asp-controller="Account" asp-action="Logout" method="post">
+
+                            <form asp-controller="Account" asp-action="Logout" method="post" class="m-0">
                                 @Html.AntiForgeryToken()
-                                <button type="submit" class="btn btn-outline-secondary btn-sm">Вийти</button>
+                                <button type="submit" class="btn app-logout-btn">Вийти</button>
                             </form>
-                        </li>
-                    </ul>
-                }
-                else
-                {
-                    <ul class="navbar-nav ms-auto">
-                        <li class="nav-item"><a class="nav-link" asp-controller="Account" asp-action="Login">Вхід</a></li>
-                    </ul>
-                }
+                        </div>
+                    }
+                    else
+                    {
+                        <ul class="navbar-nav ms-auto">
+                            <li class="nav-item">
+                                <a class="nav-link app-nav-link" asp-controller="Account" asp-action="Login">Вхід</a>
+                            </li>
+                        </ul>
+                    }
+                </div>
             </div>
-        </div>
-    </nav>
+        </nav>
+    </header>
 
-    <div class="container">
+    <main class="container app-main-content">
         @RenderBody()
-    </div>
+    </main>
 
-    <footer class="mt-auto text-center py-3 border-top">
-        <p>&copy; 2025 ClientsApp</p>
+    <footer class="app-footer mt-auto">
+        <div class="container">
+            <p>&copy; 2025 ClientsApp</p>
+        </div>
     </footer>
 
     @RenderSection("Scripts", required: false)

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -1,72 +1,336 @@
+:root {
+    --app-bg: #f5f7fb;
+    --header-gradient: linear-gradient(135deg, #1e3a5f, #2f5f9b);
+    --text-primary: #162132;
+    --text-secondary: #4b5d79;
+    --card-bg: #ffffff;
+    --card-shadow: 0 10px 30px rgba(20, 49, 89, 0.09);
+    --card-shadow-hover: 0 18px 36px rgba(20, 49, 89, 0.16);
+    --border-soft: rgba(255, 255, 255, 0.18);
+    --link-highlight: #dce9ff;
+    --focus-ring: #8dc4ff;
+}
+
 html {
-  font-size: 14px;
+    font-size: 15px;
+    position: relative;
+    min-height: 100%;
 }
 
 @media (min-width: 768px) {
-  html {
-    font-size: 16px;
-  }
+    html {
+        font-size: 16px;
+    }
 }
 
-.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+body.app-shell {
+    margin: 0;
+    background:
+        radial-gradient(circle at 10% 0%, rgba(119, 167, 255, 0.18), transparent 35%),
+        radial-gradient(circle at 100% 10%, rgba(99, 188, 255, 0.16), transparent 28%),
+        var(--app-bg);
+    color: var(--text-primary);
+    font-family: "Inter", "Segoe UI", Roboto, Arial, sans-serif;
+    line-height: 1.5;
 }
 
-html {
-  position: relative;
-  min-height: 100%;
+.app-header {
+    background: var(--header-gradient);
+    box-shadow: 0 14px 24px rgba(18, 42, 73, 0.25);
+    border-bottom: 1px solid var(--border-soft);
 }
 
-.form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
-  color: var(--bs-secondary-color);
-  text-align: end;
+.app-navbar {
+    padding: 0.85rem 0;
 }
 
-.form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
-  text-align: start;
+.app-navbar-container {
+    align-items: center;
+    row-gap: 0.75rem;
 }
 
-body {
-    font-family: Arial, sans-serif;
+.app-brand {
+    color: #ffffff;
+    font-size: 1.65rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    margin-right: 1rem;
 }
 
-.navbar-nav .nav-link {
-    color: #000;
+.app-brand:hover,
+.app-brand:focus-visible {
+    color: #eff6ff;
 }
 
-.navbar-nav .nav-link:hover,
-.navbar-nav .nav-link:focus {
-    color: #0d6efd;
-    text-decoration: underline;
+.app-navbar-toggler {
+    border-color: rgba(255, 255, 255, 0.4);
+    background-color: rgba(255, 255, 255, 0.08);
 }
 
-.navbar-nav .nav-link.active {
-    color: #0d6efd;
-    font-weight: bold;
-    text-decoration: underline;
+.app-navbar-toggler .navbar-toggler-icon {
+    filter: invert(1) grayscale(100%);
 }
 
-.navbar-brand:hover,
-.navbar-brand:focus {
-    color: #0d6efd;
+.app-nav-center {
+    flex: 1;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.55rem;
+    margin: 0 0.5rem;
+}
+
+.app-nav-link {
+    color: #eaf2ff;
+    font-weight: 500;
+    border-radius: 999px;
+    padding: 0.45rem 0.82rem;
+    transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.app-nav-link:hover,
+.app-nav-link:focus-visible {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.16);
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+
+.app-nav-link.active {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.24);
+    box-shadow: inset 0 -2px 0 #ffffff;
+}
+
+.app-nav-right {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    min-width: 210px;
+}
+
+.app-user-email,
+.app-user-link {
+    color: #eef5ff;
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+.app-user-link {
     text-decoration: none;
 }
 
-.home-links a {
-    display: block;
-    margin-bottom: 0.5rem;
-    color: #0d6efd;
-    text-decoration: none;
-}
-
-.home-links a:hover,
-.home-links a:focus {
-    color: #0a58ca;
+.app-user-link:hover,
+.app-user-link:focus-visible {
+    color: #ffffff;
     text-decoration: underline;
 }
 
-footer {
-    background-color: #f8f9fa;
+.app-logout-btn {
+    background-color: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.42);
+    color: #ffffff;
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.9rem;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.app-logout-btn:hover,
+.app-logout-btn:focus-visible {
+    background-color: rgba(255, 255, 255, 0.24);
+    border-color: rgba(255, 255, 255, 0.72);
+    color: #ffffff;
+}
+
+.app-main-content {
+    width: min(1200px, 100% - 2rem);
+    margin-top: 2.4rem;
+    margin-bottom: 2rem;
+}
+
+.home-hero {
+    margin-bottom: 2.1rem;
+    padding: 2.6rem 1rem 1.5rem;
+}
+
+.home-hero-title {
+    font-size: clamp(1.9rem, 4vw, 3rem);
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 0.95rem;
+    color: #10253f;
+}
+
+.home-hero-subtitle {
+    max-width: 760px;
+    margin: 0 auto;
+    color: var(--text-secondary);
+    font-size: clamp(1rem, 1.8vw, 1.2rem);
+}
+
+.home-cards {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.2rem;
+    margin-bottom: 2rem;
+}
+
+.dashboard-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.95rem;
+    padding: 1.25rem;
+    background: var(--card-bg);
+    border-radius: 12px;
+    border: 1px solid rgba(17, 36, 63, 0.05);
+    text-decoration: none;
+    color: inherit;
+    box-shadow: var(--card-shadow);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    min-height: 134px;
+}
+
+.dashboard-card:hover,
+.dashboard-card:focus-visible {
+    transform: scale(1.02);
+    box-shadow: var(--card-shadow-hover);
+    border-color: rgba(47, 95, 155, 0.35);
+    text-decoration: none;
+    color: inherit;
+}
+
+.card-icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    background: linear-gradient(145deg, #e7f0ff, #f2f7ff);
+    color: #2a5a95;
+}
+
+.card-icon svg {
+    width: 23px;
+    height: 23px;
+}
+
+.card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.card-title {
+    font-size: 1.08rem;
+    font-weight: 650;
+    color: #1a3355;
+}
+
+.card-description {
+    color: #5b6e8a;
+    font-size: 0.95rem;
+}
+
+.app-footer {
+    border-top: 1px solid rgba(22, 50, 85, 0.12);
+    background-color: rgba(255, 255, 255, 0.72);
+    backdrop-filter: blur(4px);
     text-align: center;
-    padding: 10px 0;
+    color: #5e728f;
+    font-size: 0.92rem;
+    padding: 0.95rem 0;
+}
+
+.table-responsive,
+.table-wrapper {
+    overflow-x: auto;
+}
+
+table {
+    min-width: 640px;
+}
+
+input,
+select,
+textarea,
+button,
+a {
+    outline: none;
+}
+
+:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+
+.btn:focus,
+.btn:active:focus,
+.btn-link.nav-link:focus,
+.form-control:focus,
+.form-check-input:focus {
+    box-shadow: 0 0 0 0.1rem #fff, 0 0 0 0.25rem rgba(58, 130, 246, 0.45);
+}
+
+.form-floating > .form-control-plaintext::placeholder,
+.form-floating > .form-control::placeholder {
+    color: var(--bs-secondary-color);
+    text-align: end;
+}
+
+.form-floating > .form-control-plaintext:focus::placeholder,
+.form-floating > .form-control:focus::placeholder {
+    text-align: start;
+}
+
+@media (max-width: 1199.98px) {
+    .app-nav-center {
+        justify-content: flex-start;
+        margin: 0.75rem 0 0;
+    }
+
+    .app-nav-right {
+        margin-top: 0.85rem;
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 991.98px) {
+    .home-cards {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .app-main-content {
+        margin-top: 2rem;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .home-hero {
+        padding-top: 1.85rem;
+    }
+
+    .home-cards {
+        grid-template-columns: 1fr;
+        gap: 0.95rem;
+    }
+
+    .dashboard-card {
+        min-height: 120px;
+    }
+
+    .row > [class*="col-"] {
+        margin-bottom: 0.85rem;
+    }
+
+    .app-main-content {
+        width: min(1200px, 100% - 1.25rem);
+    }
+
+    table {
+        min-width: 560px;
+    }
 }


### PR DESCRIPTION
### Motivation
- Refresh the homepage and application shell into a modern Admin/SaaS dashboard layout while preserving all existing functionality, routes, texts and role-based logic.
- Improve discoverability by converting the existing homepage links into prominent clickable cards with icons and a clear hero section.
- Provide a consistent light SaaS visual language (gradient header, soft card shadows, rounded corners, improved spacing) and better responsive / accessibility defaults.

### Description
- Rebuilt the application shell in `Views/Shared/_Layout.cshtml` to a top-bar SaaS header with left brand, centered role-sensitive navigation (supports 6/7 links with wrapping), and right-aligned user email/profile + logout; preserved all original `asp-controller`/`asp-action` routes and Manager-only `Register` link.
- Replaced the old home view with a dashboard landing page in `Views/Home/Index.cshtml` containing a centered hero and a responsive card grid (3/2/1 columns) where each card is a fully-clickable link keeping the original Ukrainian titles and routes and using inline SVG icons only.
- Rewrote and extended `wwwroot/css/site.css` to implement the requested style guide (background `#f5f7fb` with CSS gradients, header dark-blue gradient, white rounded cards with 12px radius and soft shadows, hover/active/focus-visible states, smooth transitions, grid responsiveness, and table overflow handling).
- Kept all role-based rendering and navigation logic unchanged; added focus-visible outlines and accessible link semantics for keyboard navigation.

### Testing
- Attempted to run `dotnet build ClientsApp/ClientsApp.csproj` in the environment, but the build could not be executed because `dotnet` is not available in this environment (error: `dotnet: command not found`).
- Visual and static checks performed by opening the modified files and verifying that all original `asp-controller`/`asp-action` routes and Ukrainian texts remain intact; no automated test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e604bf75988328982790f3a9f2d929)