### PR TITLE
Refine Client Create/Edit pages to match app design system

### DIFF
--- a/ClientsApp/Views/Client/Create.cshtml
+++ b/ClientsApp/Views/Client/Create.cshtml
@@ -5,35 +5,41 @@
     Layout = "_Layout";
 }
 
-<h2>@ViewData["Title"]</h2>
+<section class="client-form-page" aria-labelledby="client-create-title">
+    <div class="client-form-card">
+        <h1 id="client-create-title" class="client-form-title">@ViewData["Title"]</h1>
 
-<form asp-action="Create" method="post">
-    <div class="form-group">
-        <label asp-for="Name"></label>
-        <input asp-for="Name" class="form-control" />
-        <span asp-validation-for="Name" class="text-danger"></span>
+        <form asp-action="Create" method="post" class="client-form" novalidate>
+            <div class="client-form-group">
+                <label asp-for="Name" class="client-form-label"></label>
+                <input asp-for="Name" class="form-control client-form-input" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-group">
+                <label asp-for="Address" class="client-form-label"></label>
+                <input asp-for="Address" class="form-control client-form-input" />
+                <span asp-validation-for="Address" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-group">
+                <label asp-for="Email" class="client-form-label"></label>
+                <input asp-for="Email" class="form-control client-form-input" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-group">
+                <label asp-for="Phone" class="client-form-label"></label>
+                <input asp-for="Phone" class="form-control client-form-input" />
+                <span asp-validation-for="Phone" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+            </div>
+        </form>
     </div>
-
-    <div class="form-group">
-        <label asp-for="Address"></label>
-        <input asp-for="Address" class="form-control" />
-        <span asp-validation-for="Address" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="Email"></label>
-        <input asp-for="Email" class="form-control" />
-        <span asp-validation-for="Email" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="Phone"></label>
-        <input asp-for="Phone" class="form-control" />
-        <span asp-validation-for="Phone" class="text-danger"></span>
-    </div>
-
-    <button type="submit" class="btn btn-success">Зберегти</button>
-</form>
+</section>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/ClientsApp/Views/Client/Edit.cshtml
+++ b/ClientsApp/Views/Client/Edit.cshtml
@@ -5,40 +5,46 @@
     Layout = "_Layout";
 }
 
-<h2>Редагувати Клієнта</h2>
+<section class="client-form-page" aria-labelledby="client-edit-title">
+    <div class="client-form-card">
+        <h1 id="client-edit-title" class="client-form-title">@ViewData["Title"]</h1>
 
-<form asp-action="Edit" method="post">
-    <div asp-validation-summary="All" class="text-danger"></div>
+        <form asp-action="Edit" method="post" class="client-form" novalidate>
+            <div asp-validation-summary="All" class="text-danger client-form-summary"></div>
 
-    <input type="hidden" asp-for="ClientId" />
+            <input type="hidden" asp-for="ClientId" />
 
-    <div class="form-group">
-        <label asp-for="Name"></label>
-        <input asp-for="Name" class="form-control" />
-        <span asp-validation-for="Name" class="text-danger"></span>
+            <div class="client-form-group">
+                <label asp-for="Name" class="client-form-label"></label>
+                <input asp-for="Name" class="form-control client-form-input" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-group">
+                <label asp-for="Address" class="client-form-label"></label>
+                <input asp-for="Address" class="form-control client-form-input" />
+                <span asp-validation-for="Address" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-group">
+                <label asp-for="Email" class="client-form-label"></label>
+                <input asp-for="Email" class="form-control client-form-input" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-group">
+                <label asp-for="Phone" class="client-form-label"></label>
+                <input asp-for="Phone" class="form-control client-form-input" />
+                <span asp-validation-for="Phone" class="text-danger"></span>
+            </div>
+
+            <div class="client-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-
-    <div class="form-group">
-        <label asp-for="Address"></label>
-        <input asp-for="Address" class="form-control" />
-        <span asp-validation-for="Address" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="Email"></label>
-        <input asp-for="Email" class="form-control" />
-        <span asp-validation-for="Email" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="Phone"></label>
-        <input asp-for="Phone" class="form-control" />
-        <span asp-validation-for="Phone" class="text-danger"></span>
-    </div>
-
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -655,3 +655,98 @@ a {
         width: 100%;
     }
 }
+
+.client-form-page {
+    display: flex;
+    justify-content: center;
+    padding: 0.4rem 0 1.2rem;
+}
+
+.client-form-card {
+    width: min(100%, 720px);
+    background: var(--card-bg);
+    border-radius: 12px;
+    box-shadow: 0 10px 24px rgba(20, 49, 89, 0.08);
+    border: 1px solid rgba(17, 36, 63, 0.05);
+    padding: 1.5rem;
+}
+
+.client-form-title {
+    margin: 0 0 1.1rem;
+    font-size: clamp(1.65rem, 2.8vw, 2rem);
+    font-weight: 700;
+    color: #10253f;
+    letter-spacing: -0.01em;
+}
+
+.client-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.95rem;
+}
+
+.client-form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.client-form-label {
+    font-weight: 600;
+    color: #1d3a5f;
+    margin: 0;
+}
+
+.client-form-input {
+    min-height: 44px;
+    border-radius: 10px;
+    border: 1px solid rgba(44, 86, 139, 0.2);
+    padding: 0.55rem 0.8rem;
+    background-color: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.client-form-input:focus {
+    border-color: rgba(47, 95, 155, 0.45);
+    box-shadow: 0 0 0 0.2rem rgba(58, 130, 246, 0.16);
+    background-color: #ffffff;
+}
+
+.client-form-summary {
+    margin-bottom: 0.15rem;
+}
+
+.client-form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.3rem;
+}
+
+.client-form-actions .btn {
+    min-height: 42px;
+    border-radius: 10px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@media (max-width: 767.98px) {
+    .client-form-page {
+        padding-bottom: 0.8rem;
+    }
+
+    .client-form-card {
+        padding: 1rem;
+    }
+
+    .client-form-actions {
+        flex-direction: column;
+    }
+
+    .client-form-actions .btn {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
### Motivation
- Align the existing Create and Edit client pages with the current ClientsApp visual system so the forms feel consistent with the homepage and Clients list. 
- Preserve all existing behavior, routes, validation, and fields while improving spacing, typography, focus states, and card layout. 

### Description
- Updated `Views/Client/Create.cshtml` to wrap the existing fields in a centered white card, add a page title element, and apply shared form classes while keeping the same inputs, labels, validation tags, and submit action. 
- Updated `Views/Client/Edit.cshtml` to use the same visual structure and classes as Create while preserving the hidden `ClientId`, validation summary, submit and cancel actions, and the `Edit` route. 
- Added a design-aligned CSS block to `wwwroot/css/site.css` (selectors prefixed with `.client-form-`) to implement the card appearance, border-radius, soft shadow, consistent input heights, rounded inputs, focus state, spacing between fields, button sizing, and responsive stacking on mobile. 
- No business logic, routes, field names, or validation rules were changed; only Razor markup and CSS were adjusted. 

### Testing
- Attempted to run a project build with `dotnet build ClientsApp.sln` in this environment, but the command failed because `dotnet` is not available here. 
- No automated unit or integration tests were executed in this environment due to the missing runtime tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e749ad8ee883289ccb8309a295218b)