### PR TITLE
Standardize table visuals across the application

### DIFF
--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -283,6 +283,57 @@ table {
     min-width: 640px;
 }
 
+.table {
+    margin-bottom: 0;
+    color: #1d2f4a;
+}
+
+.table > :not(caption) > * > * {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 0.7rem;
+    padding-right: 0.7rem;
+    vertical-align: middle;
+    line-height: 1.3;
+    border-color: rgba(20, 49, 89, 0.06);
+}
+
+.table > thead > tr > th {
+    border-top: 0;
+    border-bottom: 1px solid rgba(20, 49, 89, 0.08);
+    background-color: #e2e8f0;
+    color: #223f64;
+    font-weight: 600;
+}
+
+.table > tbody > tr {
+    transition: background-color 0.2s ease;
+}
+
+.table > tbody > tr:not([class*="table-"]):nth-child(odd) {
+    background-color: #ffffff;
+}
+
+.table > tbody > tr:not([class*="table-"]):nth-child(even) {
+    background-color: #eef2f7;
+}
+
+.table > tbody > tr:hover {
+    background-color: #e6f0ff;
+}
+
+.table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: #ffffff !important;
+}
+
+.table-striped > tbody > tr:nth-of-type(even) {
+    background-color: #eef2f7 !important;
+}
+
+.table-striped > tbody > tr[class*="table-"] {
+    background-color: inherit !important;
+}
+
 input,
 select,
 textarea,
@@ -543,43 +594,11 @@ a {
     color: #1d2f4a;
 }
 
-.clients-table thead th {
-    border-top: 0;
-    border-bottom: 1px solid rgba(31, 79, 136, 0.12);
-    background-color: #eaf2ff;
-    color: #223f64;
-    font-weight: 700;
-    padding: 0.68rem 0.7rem;
-    vertical-align: middle;
-}
-
+.clients-table thead th,
 .clients-table tbody td {
-    padding: 0.5rem 0.68rem;
-    vertical-align: middle;
-    border-color: rgba(20, 49, 89, 0.05);
-    line-height: 1.25;
-}
-
-.clients-table tbody tr:nth-child(even) {
-    background-color: #f1f5f9;
-}
-
-.clients-table tbody tr:nth-child(odd) {
-    background-color: #ffffff;
-}
-
-.clients-table tbody tr {
-    transition: background-color 0.2s ease;
-}
-
-.clients-table tbody tr:hover {
-    background-color: rgba(226, 236, 248, 0.9);
-}
-
-.clients-table th,
-.clients-table td {
     white-space: nowrap;
 }
+
 
 .clients-table td:nth-child(1),
 .clients-table td:nth-child(2),


### PR DESCRIPTION
### Motivation
- Unify table appearance across the app to a single, compact, modern design derived from the existing Clients table without changing table markup, columns, or functionality.  
- Reduce vertical space and increase zebra contrast so all pages share the same readable SaaS-style tables.  
- Ensure Bootstrap `.table-striped` and contextual row classes do not override the new shared look.

### Description
- Added a global table style block targeting `.table` that enforces compact row padding (`8px` top/bottom), tighter `line-height`, and unified cell padding.  
- Implemented consistent zebra striping using `tr:nth-child(odd)` = `#ffffff` and `tr:nth-child(even)` = `#eef2f7`, a subtle hover (`#e6f0ff`) with `0.2s` transition, and a lightly highlighted header background `#e2e8f0` with `font-weight: 600`.  
- Added explicit overrides for Bootstrap `.table-striped > tbody > tr:nth-of-type(...)` (with `!important`) and excluded rows with contextual classes (`[class*="table-"]`) so contextual/status rows remain unaffected.  
- Simplified the client-specific `.clients-table` rules so it inherits the shared `.table` visuals while preserving client-only layout behaviors (nowrap, ellipsis truncation, and actions grid).  
- Modified file: `ClientsApp/wwwroot/css/site.css` (CSS-only change).

### Testing
- Attempted to build the solution with `dotnet build ClientsApp.sln`, which could not be executed in this environment because `dotnet` is not installed (build not run).  
- Verified the CSS insertion and selector changes with local grep/sed commands in the repository, confirming the new `.table` block and the `.table-striped` overrides were added and the `.clients-table` selectors were adjusted.  
- No unit or integration tests were run because the change is CSS-only and the environment lacks the `.NET` toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74d9b005c83288ed9201c86884b31)