### PR TITLE
Unify standard CRUD page UI across ClientsApp

### DIFF
--- a/ClientsApp/Views/Client/Create.cshtml
+++ b/ClientsApp/Views/Client/Create.cshtml
@@ -5,36 +5,36 @@
     Layout = "_Layout";
 }
 
-<section class="client-form-page" aria-labelledby="client-create-title">
-    <div class="client-form-card">
-        <h1 id="client-create-title" class="client-form-title">@ViewData["Title"]</h1>
+<section class="app-form-page" aria-labelledby="client-create-title">
+    <div class="app-form-card">
+        <h1 id="client-create-title" class="app-form-title">@ViewData["Title"]</h1>
 
-        <form asp-action="Create" method="post" class="client-form" novalidate>
-            <div class="client-form-group">
-                <label asp-for="Name" class="client-form-label"></label>
-                <input asp-for="Name" class="form-control client-form-input" />
+        <form asp-action="Create" method="post" class="app-form" novalidate>
+            <div class="app-form-group">
+                <label asp-for="Name" class="app-form-label"></label>
+                <input asp-for="Name" class="form-control app-form-input" />
                 <span asp-validation-for="Name" class="text-danger"></span>
             </div>
 
-            <div class="client-form-group">
-                <label asp-for="Address" class="client-form-label"></label>
-                <input asp-for="Address" class="form-control client-form-input" />
+            <div class="app-form-group">
+                <label asp-for="Address" class="app-form-label"></label>
+                <input asp-for="Address" class="form-control app-form-input" />
                 <span asp-validation-for="Address" class="text-danger"></span>
             </div>
 
-            <div class="client-form-group">
-                <label asp-for="Email" class="client-form-label"></label>
-                <input asp-for="Email" class="form-control client-form-input" />
+            <div class="app-form-group">
+                <label asp-for="Email" class="app-form-label"></label>
+                <input asp-for="Email" class="form-control app-form-input" />
                 <span asp-validation-for="Email" class="text-danger"></span>
             </div>
 
-            <div class="client-form-group">
-                <label asp-for="Phone" class="client-form-label"></label>
-                <input asp-for="Phone" class="form-control client-form-input" />
+            <div class="app-form-group">
+                <label asp-for="Phone" class="app-form-label"></label>
+                <input asp-for="Phone" class="form-control app-form-input" />
                 <span asp-validation-for="Phone" class="text-danger"></span>
             </div>
 
-            <div class="client-form-actions">
+            <div class="app-form-actions">
                 <button type="submit" class="btn btn-success">Зберегти</button>
             </div>
         </form>

--- a/ClientsApp/Views/Client/Edit.cshtml
+++ b/ClientsApp/Views/Client/Edit.cshtml
@@ -5,40 +5,40 @@
     Layout = "_Layout";
 }
 
-<section class="client-form-page" aria-labelledby="client-edit-title">
-    <div class="client-form-card">
-        <h1 id="client-edit-title" class="client-form-title">@ViewData["Title"]</h1>
+<section class="app-form-page" aria-labelledby="client-edit-title">
+    <div class="app-form-card">
+        <h1 id="client-edit-title" class="app-form-title">@ViewData["Title"]</h1>
 
-        <form asp-action="Edit" method="post" class="client-form" novalidate>
-            <div asp-validation-summary="All" class="text-danger client-form-summary"></div>
+        <form asp-action="Edit" method="post" class="app-form" novalidate>
+            <div asp-validation-summary="All" class="text-danger app-form-summary"></div>
 
             <input type="hidden" asp-for="ClientId" />
 
-            <div class="client-form-group">
-                <label asp-for="Name" class="client-form-label"></label>
-                <input asp-for="Name" class="form-control client-form-input" />
+            <div class="app-form-group">
+                <label asp-for="Name" class="app-form-label"></label>
+                <input asp-for="Name" class="form-control app-form-input" />
                 <span asp-validation-for="Name" class="text-danger"></span>
             </div>
 
-            <div class="client-form-group">
-                <label asp-for="Address" class="client-form-label"></label>
-                <input asp-for="Address" class="form-control client-form-input" />
+            <div class="app-form-group">
+                <label asp-for="Address" class="app-form-label"></label>
+                <input asp-for="Address" class="form-control app-form-input" />
                 <span asp-validation-for="Address" class="text-danger"></span>
             </div>
 
-            <div class="client-form-group">
-                <label asp-for="Email" class="client-form-label"></label>
-                <input asp-for="Email" class="form-control client-form-input" />
+            <div class="app-form-group">
+                <label asp-for="Email" class="app-form-label"></label>
+                <input asp-for="Email" class="form-control app-form-input" />
                 <span asp-validation-for="Email" class="text-danger"></span>
             </div>
 
-            <div class="client-form-group">
-                <label asp-for="Phone" class="client-form-label"></label>
-                <input asp-for="Phone" class="form-control client-form-input" />
+            <div class="app-form-group">
+                <label asp-for="Phone" class="app-form-label"></label>
+                <input asp-for="Phone" class="form-control app-form-input" />
                 <span asp-validation-for="Phone" class="text-danger"></span>
             </div>
 
-            <div class="client-form-actions">
+            <div class="app-form-actions">
                 <button type="submit" class="btn btn-success">Зберегти</button>
                 <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
             </div>

--- a/ClientsApp/Views/Client/Index.cshtml
+++ b/ClientsApp/Views/Client/Index.cshtml
@@ -11,55 +11,38 @@
     var dateArrowDirectionClass = isDateSortActive && currentSortDirection == "asc" ? "is-asc" : "is-desc";
 }
 
-<section class="clients-page">
-    <div class="clients-page-header">
-        <h1 class="clients-page-title">@ViewData["Title"]</h1>
-        <p class="clients-page-description">На цій сторінці Клієнти Ви можете отримати усю інформацію по клієнтах фірми,  а також додавати інформацію, редагувати та видаляти її.</p>
-        <p class="clients-page-description">Ви можете здійснювати пошук клієнтів за їх назвою, у тому числі частковою.</p>
-        <a asp-action="Create" class="btn btn-success clients-add-btn">Додати клієнта</a>
+<section class="app-page">
+    <div class="app-page-header">
+        <h1 class="app-page-title">@ViewData["Title"]</h1>
+        <p class="app-page-description">На цій сторінці Клієнти Ви можете отримати усю інформацію по клієнтах фірми,  а також додавати інформацію, редагувати та видаляти її.</p>
+        <p class="app-page-description">Ви можете здійснювати пошук клієнтів за їх назвою, у тому числі частковою.</p>
+        <div class="app-page-actions">
+            <a asp-action="Create" class="btn btn-success app-primary-action">Додати клієнта</a>
+        </div>
     </div>
 
-    <div class="clients-controls-grid">
-        <section class="clients-card clients-filters-card" aria-label="Фільтри клієнтів">
-            <h2 class="clients-card-title">
-                <span class="clients-card-title-icon" aria-hidden="true">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                        <path d="M3 5h18M6 12h12M10 19h4" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <span>Фільтри</span>
-            </h2>
-
-            <form method="get" class="clients-filters-form">
+    <div class="app-controls-grid">
+        <section class="app-control-card" aria-label="Фільтри клієнтів">
+            <h2 class="app-control-card-title">Фільтри</h2>
+            <form method="get" class="app-filters-form">
                 <input type="hidden" name="sortBy" value="@currentSortBy" />
                 <input type="hidden" name="sortDirection" value="@currentSortDirection" />
-                <input type="text"
-                       name="searchString"
-                       value="@ViewData["SearchString"]"
-                       class="form-control clients-search-input"
-                       placeholder="Пошук за ім’ям"
-                       minlength="3" />
-                <button type="submit" class="btn btn-primary">Пошук</button>
-                <a asp-action="Index" class="btn btn-outline-secondary" id="resetFilters">Скинути</a>
+                <div class="app-form-field--wide">
+                    <input type="text" name="searchString" value="@ViewData["SearchString"]" class="form-control" placeholder="Пошук за ім’ям" minlength="3" />
+                </div>
+                <div class="app-form-field">
+                    <button type="submit" class="btn btn-primary w-100">Пошук</button>
+                </div>
+                <div class="app-form-field">
+                    <a asp-action="Index" class="btn btn-outline-secondary w-100" id="resetFilters">Скинути</a>
+                </div>
             </form>
         </section>
 
-        <section class="clients-card clients-sort-card" aria-label="Сортування клієнтів">
-            <h2 class="clients-card-title">
-                <span class="clients-card-title-icon" aria-hidden="true">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                        <path d="M6 7h12M6 12h8M6 17h4" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <span>Сортування</span>
-            </h2>
-
-            <div class="clients-sort-buttons">
-                <a asp-action="Index"
-                   asp-route-searchString="@ViewData["SearchString"]"
-                   asp-route-sortBy="id"
-                   asp-route-sortDirection="@nextIdDirection"
-                   class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
+        <section class="app-control-card" aria-label="Сортування клієнтів">
+            <h2 class="app-control-card-title">Сортування</h2>
+            <div class="app-sort-buttons">
+                <a asp-action="Index" asp-route-searchString="@ViewData["SearchString"]" asp-route-sortBy="id" asp-route-sortDirection="@nextIdDirection" class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
                     <span class="sort-label-with-icon">
                         <span>За датою додавання</span>
                         <span class="sort-arrow @dateArrowDirectionClass" aria-hidden="true">
@@ -69,27 +52,21 @@
                         </span>
                     </span>
                 </a>
-                <a asp-action="Index"
-                   asp-route-searchString="@ViewData["SearchString"]"
-                   asp-route-sortBy="name"
-                   asp-route-sortDirection="@nextNameDirection"
-                   class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">
-                    <span>За назвою (А–Я)</span>
-                </a>
+                <a asp-action="Index" asp-route-searchString="@ViewData["SearchString"]" asp-route-sortBy="name" asp-route-sortDirection="@nextNameDirection" class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">За назвою (А–Я)</a>
             </div>
         </section>
     </div>
 
-    <section class="clients-card clients-table-card" aria-label="Таблиця клієнтів">
-        <div class="table-responsive app-table-wrap clients-table-wrap">
-            <table class="table table-striped app-table clients-table mb-0">
+    <section class="app-table-card" aria-label="Таблиця клієнтів">
+        <div class="table-responsive app-table-wrap">
+            <table class="table table-striped app-table mb-0">
                 <thead>
                     <tr>
                         <th>Ім'я</th>
                         <th>Адреса</th>
                         <th>Email</th>
                         <th>Телефон</th>
-                        <th>Дії</th>
+                        <th class="app-cell-actions">Дії</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -100,7 +77,7 @@
                             <td>@client.Address</td>
                             <td>@client.Email</td>
                             <td>@client.Phone</td>
-                            <td>
+                            <td class="app-cell-actions">
                                 <div class="app-table-actions">
                                     <a asp-action="Edit" asp-route-id="@client.ClientId" class="btn btn-primary btn-sm">Редагувати</a>
                                     <a asp-action="Delete" asp-route-id="@client.ClientId" class="btn btn-danger btn-sm">Видалити</a>

--- a/ClientsApp/Views/ClientTask/Create.cshtml
+++ b/ClientsApp/Views/ClientTask/Create.cshtml
@@ -7,83 +7,89 @@
     var selectedExecutors = ViewBag.SelectedExecutors as HashSet<int> ?? new HashSet<int>();
 }
 
-<h2>Додати завдання</h2>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">Додати завдання</h1>
 
-<form asp-action="Create" method="post">
-    <div class="form-group">
-        <label asp-for="ClientId"></label>
-        <select asp-for="ClientId" class="form-control" asp-items="ViewBag.Clients">
-            <option value="">Виберіть клієнта</option>
-        </select>
-        <span asp-validation-for="ClientId" class="text-danger"></span>
+        <form asp-action="Create" method="post" class="app-form">
+            <div class="app-form-group">
+                <label asp-for="ClientId" class="app-form-label"></label>
+                <select asp-for="ClientId" class="form-select app-form-input" asp-items="ViewBag.Clients">
+                    <option value="">Виберіть клієнта</option>
+                </select>
+                <span asp-validation-for="ClientId" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="TaskTitle" class="app-form-label"></label>
+                <input asp-for="TaskTitle" class="form-control app-form-input" />
+                <span asp-validation-for="TaskTitle" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="Description" class="app-form-label"></label>
+                <input asp-for="Description" class="form-control app-form-input" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="StartDate" class="app-form-label"></label>
+                <input asp-for="StartDate" type="date" class="form-control app-form-input" />
+                <span asp-validation-for="StartDate" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="EndDate" class="app-form-label"></label>
+                <input asp-for="EndDate" type="date" class="form-control app-form-input" />
+                <span asp-validation-for="EndDate" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label class="app-form-label">Виконавці</label>
+                <select id="selectedExecutors" name="selectedExecutors" class="form-select app-form-input" multiple>
+                    @foreach (var executor in executors)
+                    {
+                        var unavailableFrom = executor.UnavailableFrom?.ToString("yyyy-MM-dd");
+                        var unavailableTo = executor.UnavailableTo?.ToString("yyyy-MM-dd");
+                        var dismissedFrom = executor.DismissedFrom?.ToString("yyyy-MM-dd");
+                        if (selectedExecutors.Contains(executor.ExecutorId))
+                        {
+                            <option value="@executor.ExecutorId"
+                                    selected="selected"
+                                    data-unavailable-from="@unavailableFrom"
+                                    data-unavailable-to="@unavailableTo"
+                                    data-dismissed-from="@dismissedFrom">
+                                @executor.FullName
+                            </option>
+                        }
+                        else
+                        {
+                            <option value="@executor.ExecutorId"
+                                    data-unavailable-from="@unavailableFrom"
+                                    data-unavailable-to="@unavailableTo"
+                                    data-dismissed-from="@dismissedFrom">
+                                @executor.FullName
+                            </option>
+                        }
+                    }
+                </select>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="TaskStatus" class="app-form-label"></label>
+                <select asp-for="TaskStatus" class="form-select app-form-input" asp-items="ViewBag.Statuses">
+                    <option value="">-- Виберіть статус --</option>
+                </select>
+                <span asp-validation-for="TaskStatus" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-
-    <div class="form-group">
-        <label asp-for="TaskTitle"></label>
-        <input asp-for="TaskTitle" class="form-control" />
-        <span asp-validation-for="TaskTitle" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="Description"></label>
-        <input asp-for="Description" class="form-control" />
-        <span asp-validation-for="Description" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="StartDate"></label>
-        <input asp-for="StartDate" type="date" class="form-control" />
-        <span asp-validation-for="StartDate" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="EndDate"></label>
-        <input asp-for="EndDate" type="date" class="form-control" />
-        <span asp-validation-for="EndDate" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label>Виконавці</label>
-        <select id="selectedExecutors" name="selectedExecutors" class="form-control" multiple>
-            @foreach (var executor in executors)
-            {
-                var unavailableFrom = executor.UnavailableFrom?.ToString("yyyy-MM-dd");
-                var unavailableTo = executor.UnavailableTo?.ToString("yyyy-MM-dd");
-                var dismissedFrom = executor.DismissedFrom?.ToString("yyyy-MM-dd");
-                if (selectedExecutors.Contains(executor.ExecutorId))
-                {
-                    <option value="@executor.ExecutorId"
-                            selected="selected"
-                            data-unavailable-from="@unavailableFrom"
-                            data-unavailable-to="@unavailableTo"
-                            data-dismissed-from="@dismissedFrom">
-                        @executor.FullName
-                    </option>
-                }
-                else
-                {
-                    <option value="@executor.ExecutorId"
-                            data-unavailable-from="@unavailableFrom"
-                            data-unavailable-to="@unavailableTo"
-                            data-dismissed-from="@dismissedFrom">
-                        @executor.FullName
-                    </option>
-                }
-            }
-        </select>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="TaskStatus"></label>
-        <select asp-for="TaskStatus" class="form-control" asp-items="ViewBag.Statuses">
-            <option value="">-- Виберіть статус --</option>
-        </select>
-        <span asp-validation-for="TaskStatus" class="text-danger"></span>
-    </div>
-
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>
 
 <div class="modal fade" id="inProgressTasksModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg">

--- a/ClientsApp/Views/ClientTask/Edit.cshtml
+++ b/ClientsApp/Views/ClientTask/Edit.cshtml
@@ -5,53 +5,59 @@
     Layout = "_Layout";
 }
 
-<h2>Редагувати завдання</h2>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">Редагувати завдання</h1>
 
-<form asp-action="Edit" method="post">
-    <input type="hidden" asp-for="ClientTaskId" />
+        <form asp-action="Edit" method="post" class="app-form">
+            <input type="hidden" asp-for="ClientTaskId" />
 
-    <div class="form-group">
-        <label asp-for="TaskTitle"></label>
-        <input asp-for="TaskTitle" class="form-control" />
-        <span asp-validation-for="TaskTitle" class="text-danger"></span>
+            <div class="app-form-group">
+                <label asp-for="TaskTitle" class="app-form-label"></label>
+                <input asp-for="TaskTitle" class="form-control app-form-input" />
+                <span asp-validation-for="TaskTitle" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="Description" class="app-form-label"></label>
+                <input asp-for="Description" class="form-control app-form-input" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="StartDate" class="app-form-label"></label>
+                <input asp-for="StartDate" type="date" class="form-control app-form-input" />
+                <span asp-validation-for="StartDate" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="EndDate" class="app-form-label"></label>
+                <input asp-for="EndDate" type="date" class="form-control app-form-input" />
+                <span asp-validation-for="EndDate" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="ClientId" class="app-form-label"></label>
+                <select asp-for="ClientId" class="form-select app-form-input" asp-items="Model.Clients">
+                    <option value="">Виберіть клієнта</option>
+                </select>
+                <span asp-validation-for="ClientId" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="SelectedExecutors" class="app-form-label">Виконавці</label>
+                <select asp-for="SelectedExecutors" class="form-select app-form-input" multiple asp-items="Model.Executors"></select>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="TaskStatus" class="app-form-label"></label>
+                <select asp-for="TaskStatus" class="form-select app-form-input" asp-items="Model.Statuses"></select>
+            </div>
+
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-
-    <div class="form-group">
-        <label asp-for="Description"></label>
-        <input asp-for="Description" class="form-control" />
-        <span asp-validation-for="Description" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="StartDate"></label>
-        <input asp-for="StartDate" type="date" class="form-control" />
-        <span asp-validation-for="StartDate" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="EndDate"></label>
-        <input asp-for="EndDate" type="date" class="form-control" />
-        <span asp-validation-for="EndDate" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="ClientId"></label>
-        <select asp-for="ClientId" class="form-control" asp-items="Model.Clients">
-            <option value="">Виберіть клієнта</option>
-        </select>
-        <span asp-validation-for="ClientId" class="text-danger"></span>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="SelectedExecutors">Виконавці</label>
-        <select asp-for="SelectedExecutors" class="form-control" multiple asp-items="Model.Executors"></select>
-    </div>
-
-    <div class="form-group">
-        <label asp-for="TaskStatus"></label>
-        <select asp-for="TaskStatus" class="form-control" asp-items="Model.Statuses"></select>
-    </div>
-
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>

--- a/ClientsApp/Views/ClientTask/Index.cshtml
+++ b/ClientsApp/Views/ClientTask/Index.cshtml
@@ -6,92 +6,107 @@
     ViewData["MainContentClass"] = "app-main-content--wide";
 }
 
-<h2>@ViewData["Title"]</h2>
-
-<p>На цій сторінці Завдання Ви можете отримати усю інформацію по усіх завданнях фірми,  а також додавати інформацію, редагувати та видаляти її. </p>
-<p>Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів. </p>
-
- <a asp-action="Create" class="btn btn-success mb-2">Додати завдання</a>
-
-<form asp-action="Index" method="get" class="row g-3 mb-3">
-    <div class="col-md-3">
-        <select asp-for="SelectedClientId" class="form-select" asp-items="Model.Clients">
-            <option value="">Всі клієнти</option>
-        </select>
+<section class="app-page">
+    <div class="app-page-header">
+        <h1 class="app-page-title">@ViewData["Title"]</h1>
+        <p class="app-page-description">На цій сторінці Завдання Ви можете отримати усю інформацію по усіх завданнях фірми,  а також додавати інформацію, редагувати та видаляти її.</p>
+        <p class="app-page-description">Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів.</p>
+        <div class="app-page-actions">
+            <a asp-action="Create" class="btn btn-success app-primary-action">Додати завдання</a>
+        </div>
     </div>
-    <div class="col-md-3">
-        <select asp-for="SelectedExecutorId" class="form-select" asp-items="Model.Executors">
-            <option value="">Всі виконавці</option>
-        </select>
-    </div>
-    <div class="col-md-3">
-        <select asp-for="SelectedStatus" class="form-select" asp-items="Model.Statuses">
-            <option value="">Всі статуси</option>
-        </select>
-    </div>
-    <div class="col-md-3 d-flex align-items-end">
-        <button type="submit" class="btn btn-primary me-2">Фільтрувати</button>
-        <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути усі фільтри</a>
-    </div>
-</form>
 
-<div class="mb-3 d-flex justify-content-md-end">
-    <a asp-action="Index"
-       asp-route-selectedClientId="@Model.SelectedClientId"
-       asp-route-selectedExecutorId="@Model.SelectedExecutorId"
-       asp-route-selectedStatus="@(Model.SelectedStatus.HasValue ? ((int)Model.SelectedStatus.Value).ToString() : null)"
-       asp-route-sortOrder="@(Model.SortOrder == "asc" ? "desc" : "asc")"
-       class="btn btn-outline-primary">
-        Сортувати за датою початку
-        <span class="ms-1">@((Model.SortOrder == "asc") ? "↑" : "↓")</span>
-    </a>
-</div>
+    <div class="app-controls-grid">
+        <section class="app-control-card" aria-label="Фільтри завдань">
+            <h2 class="app-control-card-title">Фільтри</h2>
+            <form asp-action="Index" method="get" class="app-filters-form">
+                <div class="app-form-field">
+                    <select asp-for="SelectedClientId" class="form-select" asp-items="Model.Clients">
+                        <option value="">Всі клієнти</option>
+                    </select>
+                </div>
+                <div class="app-form-field">
+                    <select asp-for="SelectedExecutorId" class="form-select" asp-items="Model.Executors">
+                        <option value="">Всі виконавці</option>
+                    </select>
+                </div>
+                <div class="app-form-field">
+                    <select asp-for="SelectedStatus" class="form-select" asp-items="Model.Statuses">
+                        <option value="">Всі статуси</option>
+                    </select>
+                </div>
+                <div class="app-form-field">
+                    <button type="submit" class="btn btn-primary w-100">Фільтрувати</button>
+                </div>
+                <div class="app-form-field">
+                    <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути усі фільтри</a>
+                </div>
+            </form>
+        </section>
 
-<div class="app-table-wrap">
-    <table class="table table-striped app-table app-table--wide">
-        <thead>
-            <tr>
-                <th>Id</th>
-                <th>Клієнт</th>
-                <th>Опис</th>
-                <th>Початок</th>
-                <th>Закінчення</th>
-                <th>Виконавці</th>
-                <th>Статус</th>
-                 <th>Дії</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var task in Model.Tasks)
-            {
-                <tr>
-                    <td>@task.ClientTaskId</td>
-                    <td>@task.Client?.Name</td>
-                    <td>@task.Description</td>
-                    <td>@task.StartDate.ToShortDateString()</td>
-                    <td>@(task.EndDate?.ToShortDateString() ?? "")</td>
-                    <td>
-                        @if (task.ExecutorTasks != null && task.ExecutorTasks.Any())
-                        {
-                            @string.Join(", ", task.ExecutorTasks.Select(et => et.Executor?.FullName).Where(name => !string.IsNullOrWhiteSpace(name)))
-                        }
-                        else
-                        {
-                            <text>-</text>
-                        }
-                    </td>
-                    <td>@task.TaskStatus</td>
-                    <td>
-                        <div class="app-table-actions">
-                            <a asp-action="Edit" asp-route-id="@task.ClientTaskId" class="btn btn-primary btn-sm">Редагувати</a>
-                            <a asp-action="Delete" asp-route-id="@task.ClientTaskId" class="btn btn-danger btn-sm">Видалити</a>
-                        </div>
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
-</div>
+        <section class="app-control-card" aria-label="Сортування завдань">
+            <h2 class="app-control-card-title">Сортування</h2>
+            <div class="app-sort-buttons">
+                <a asp-action="Index"
+                   asp-route-selectedClientId="@Model.SelectedClientId"
+                   asp-route-selectedExecutorId="@Model.SelectedExecutorId"
+                   asp-route-selectedStatus="@(Model.SelectedStatus.HasValue ? ((int)Model.SelectedStatus.Value).ToString() : null)"
+                   asp-route-sortOrder="@(Model.SortOrder == "asc" ? "desc" : "asc")"
+                   class="btn btn-outline-primary">
+                    Сортувати за датою початку <span class="ms-1">@((Model.SortOrder == "asc") ? "↑" : "↓")</span>
+                </a>
+            </div>
+        </section>
+    </div>
+
+    <section class="app-table-card">
+        <div class="app-table-wrap">
+            <table class="table table-striped app-table app-table--wide mb-0">
+                <thead>
+                    <tr>
+                        <th>Id</th>
+                        <th>Клієнт</th>
+                        <th>Опис</th>
+                        <th>Початок</th>
+                        <th>Закінчення</th>
+                        <th>Виконавці</th>
+                        <th>Статус</th>
+                        <th class="app-cell-actions">Дії</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var task in Model.Tasks)
+                    {
+                        <tr>
+                            <td>@task.ClientTaskId</td>
+                            <td>@task.Client?.Name</td>
+                            <td>@task.Description</td>
+                            <td>@task.StartDate.ToShortDateString()</td>
+                            <td>@(task.EndDate?.ToShortDateString() ?? "")</td>
+                            <td>
+                                @if (task.ExecutorTasks != null && task.ExecutorTasks.Any())
+                                {
+                                    @string.Join(", ", task.ExecutorTasks.Select(et => et.Executor?.FullName).Where(name => !string.IsNullOrWhiteSpace(name)))
+                                }
+                                else
+                                {
+                                    <text>-</text>
+                                }
+                            </td>
+                            <td>@task.TaskStatus</td>
+                            <td class="app-cell-actions">
+                                <div class="app-table-actions">
+                                    <a asp-action="Edit" asp-route-id="@task.ClientTaskId" class="btn btn-primary btn-sm">Редагувати</a>
+                                    <a asp-action="Delete" asp-route-id="@task.ClientTaskId" class="btn btn-danger btn-sm">Видалити</a>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
+</section>
 
 @section Scripts {
     <script>

--- a/ClientsApp/Views/Executor/Create.cshtml
+++ b/ClientsApp/Views/Executor/Create.cshtml
@@ -5,49 +5,54 @@
     var today = DateTime.Today.ToString("yyyy-MM-dd");
 }
 
-<h2>@ViewData["Title"]</h2>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">@ViewData["Title"]</h1>
+        <form asp-action="Create" method="post" class="app-form">
+            <div class="app-form-group">
+                <label asp-for="FullName" class="app-form-label"></label>
+                <input asp-for="FullName" class="form-control app-form-input" />
+                <span asp-validation-for="FullName" class="text-danger"></span>
+            </div>
 
-<form asp-action="Create" method="post">
-    <div class="mb-3">
-        <label asp-for="FullName" class="form-label"></label>
-        <input asp-for="FullName" class="form-control" />
-        <span asp-validation-for="FullName" class="text-danger"></span>
+            <div class="app-form-group">
+                <label asp-for="HourlyRate" class="app-form-label"></label>
+                <input asp-for="HourlyRate" asp-format="{0:0}" class="form-control app-form-input" type="text" inputmode="numeric" pattern="[0-9]+" />
+                <span asp-validation-for="HourlyRate" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="Email" class="app-form-label"></label>
+                <input asp-for="Email" class="form-control app-form-input" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="DismissedFrom" class="app-form-label"></label>
+                <input asp-for="DismissedFrom" type="date" class="form-control app-form-input" min="@today" />
+                <span asp-validation-for="DismissedFrom" class="text-danger"></span>
+            </div>
+
+            <div class="row">
+                <div class="col-md-6 app-form-group">
+                    <label asp-for="UnavailableFrom" class="app-form-label"></label>
+                    <input asp-for="UnavailableFrom" type="date" class="form-control app-form-input" min="@today" />
+                    <span asp-validation-for="UnavailableFrom" class="text-danger"></span>
+                </div>
+                <div class="col-md-6 app-form-group">
+                    <label asp-for="UnavailableTo" class="app-form-label"></label>
+                    <input asp-for="UnavailableTo" type="date" class="form-control app-form-input" min="@today" />
+                    <span asp-validation-for="UnavailableTo" class="text-danger"></span>
+                </div>
+            </div>
+
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Створити</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-
-    <div class="mb-3">
-        <label asp-for="HourlyRate" class="form-label"></label>
-        <input asp-for="HourlyRate" asp-format="{0:0}" class="form-control" type="text" inputmode="numeric" pattern="[0-9]+" />
-        <span asp-validation-for="HourlyRate" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Email" class="form-label"></label>
-        <input asp-for="Email" class="form-control" />
-        <span asp-validation-for="Email" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="DismissedFrom" class="form-label"></label>
-        <input asp-for="DismissedFrom" type="date" class="form-control" min="@today" />
-        <span asp-validation-for="DismissedFrom" class="text-danger"></span>
-    </div>
-
-    <div class="row">
-        <div class="mb-3 col-md-6">
-            <label asp-for="UnavailableFrom" class="form-label"></label>
-            <input asp-for="UnavailableFrom" type="date" class="form-control" min="@today" />
-            <span asp-validation-for="UnavailableFrom" class="text-danger"></span>
-        </div>
-        <div class="mb-3 col-md-6">
-            <label asp-for="UnavailableTo" class="form-label"></label>
-            <input asp-for="UnavailableTo" type="date" class="form-control" min="@today" />
-            <span asp-validation-for="UnavailableTo" class="text-danger"></span>
-        </div>
-    </div>
-
-    <button type="submit" class="btn btn-success">Створити</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/ClientsApp/Views/Executor/Edit.cshtml
+++ b/ClientsApp/Views/Executor/Edit.cshtml
@@ -5,51 +5,56 @@
     var today = DateTime.Today.ToString("yyyy-MM-dd");
 }
 
-<h2>@ViewData["Title"]</h2>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">@ViewData["Title"]</h1>
+        <form asp-action="Edit" method="post" class="app-form">
+            <input type="hidden" asp-for="ExecutorId" />
 
-<form asp-action="Edit" method="post">
-    <input type="hidden" asp-for="ExecutorId" />
+            <div class="app-form-group">
+                <label asp-for="FullName" class="app-form-label"></label>
+                <input asp-for="FullName" class="form-control app-form-input" />
+                <span asp-validation-for="FullName" class="text-danger"></span>
+            </div>
 
-    <div class="mb-3">
-        <label asp-for="FullName" class="form-label"></label>
-        <input asp-for="FullName" class="form-control" />
-        <span asp-validation-for="FullName" class="text-danger"></span>
+            <div class="app-form-group">
+                <label asp-for="HourlyRate" class="app-form-label"></label>
+                <input asp-for="HourlyRate" asp-format="{0:0}" class="form-control app-form-input" type="text" inputmode="numeric" pattern="[0-9]+" />
+                <span asp-validation-for="HourlyRate" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="Email" class="app-form-label"></label>
+                <input asp-for="Email" class="form-control app-form-input" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="DismissedFrom" class="app-form-label"></label>
+                <input asp-for="DismissedFrom" type="date" class="form-control app-form-input" min="@today" />
+                <span asp-validation-for="DismissedFrom" class="text-danger"></span>
+            </div>
+
+            <div class="row">
+                <div class="col-md-6 app-form-group">
+                    <label asp-for="UnavailableFrom" class="app-form-label"></label>
+                    <input asp-for="UnavailableFrom" type="date" class="form-control app-form-input" min="@today" />
+                    <span asp-validation-for="UnavailableFrom" class="text-danger"></span>
+                </div>
+                <div class="col-md-6 app-form-group">
+                    <label asp-for="UnavailableTo" class="app-form-label"></label>
+                    <input asp-for="UnavailableTo" type="date" class="form-control app-form-input" min="@today" />
+                    <span asp-validation-for="UnavailableTo" class="text-danger"></span>
+                </div>
+            </div>
+
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-
-    <div class="mb-3">
-        <label asp-for="HourlyRate" class="form-label"></label>
-        <input asp-for="HourlyRate" asp-format="{0:0}" class="form-control" type="text" inputmode="numeric" pattern="[0-9]+" />
-        <span asp-validation-for="HourlyRate" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Email" class="form-label"></label>
-        <input asp-for="Email" class="form-control" />
-        <span asp-validation-for="Email" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="DismissedFrom" class="form-label"></label>
-        <input asp-for="DismissedFrom" type="date" class="form-control" min="@today" />
-        <span asp-validation-for="DismissedFrom" class="text-danger"></span>
-    </div>
-
-    <div class="row">
-        <div class="mb-3 col-md-6">
-            <label asp-for="UnavailableFrom" class="form-label"></label>
-            <input asp-for="UnavailableFrom" type="date" class="form-control" min="@today" />
-            <span asp-validation-for="UnavailableFrom" class="text-danger"></span>
-        </div>
-        <div class="mb-3 col-md-6">
-            <label asp-for="UnavailableTo" class="form-label"></label>
-            <input asp-for="UnavailableTo" type="date" class="form-control" min="@today" />
-            <span asp-validation-for="UnavailableTo" class="text-danger"></span>
-        </div>
-    </div>
-
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/ClientsApp/Views/Executor/Index.cshtml
+++ b/ClientsApp/Views/Executor/Index.cshtml
@@ -9,97 +9,105 @@
     var nextIdDirection = currentSortBy == "id" && currentSortDirection == "desc" ? "asc" : "desc";
 }
 
-<h2>@ViewData["Title"]</h2>
-
-<p>На цій сторінці Виконавці Ви можете отримати усю інформацію по усіх виконавцях фірми,  а також додавати інформацію, редагувати та видаляти її. </p>
-
-<form method="get" class="row g-3 mb-3">
-    <input type="hidden" name="sortBy" value="@currentSortBy" />
-    <input type="hidden" name="sortDirection" value="@currentSortDirection" />
-    <div class="col-md-4">
-        <input type="text" name="fullName" value="@ViewData["FullName"]" class="form-control" placeholder="Пошук за ПІБ" />
+<section class="app-page">
+    <div class="app-page-header">
+        <h1 class="app-page-title">@ViewData["Title"]</h1>
+        <p class="app-page-description">На цій сторінці Виконавці Ви можете отримати усю інформацію по усіх виконавцях фірми,  а також додавати інформацію, редагувати та видаляти її.</p>
+        <div class="app-page-actions">
+            <a asp-action="Create" class="btn btn-success app-primary-action">Додати Виконавця</a>
+        </div>
     </div>
-    <div class="col-md-3">
-        <input type="text" name="hourlyRate" value="@ViewData["HourlyRate"]" class="form-control" placeholder="Пошук за ставкою" inputmode="numeric" pattern="[0-9]+" />
-    </div>
-    <div class="col-md-2">
-        <select name="statusFilter" class="form-select">
-            <option value="all" selected="@(selectedStatus == "all" ? "selected" : null)">Усі</option>
-            <option value="working" selected="@(selectedStatus == "working" ? "selected" : null)">Працює</option>
-            <option value="dismissed" selected="@(selectedStatus == "dismissed" ? "selected" : null)">Звільнений</option>
-        </select>
-    </div>
-    <div class="col-md-3 d-flex align-items-end">
-        <button type="submit" class="btn btn-primary me-2">Пошук</button>
-        <a asp-action="Index" class="btn btn-secondary">Скинути</a>
-    </div>
-</form>
 
-<div class="mb-3 d-flex gap-2">
-    <a asp-action="Index"
-       asp-route-fullName="@ViewData["FullName"]"
-       asp-route-hourlyRate="@ViewData["HourlyRate"]"
-       asp-route-statusFilter="@selectedStatus"
-       asp-route-sortBy="name"
-       asp-route-sortDirection="@nextNameDirection"
-       class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">
-        Сортувати за ПІБ
-        @if (currentSortBy == "name")
-        {
-            <span>@(currentSortDirection == "asc" ? "↑" : "↓")</span>
-        }
-    </a>
-    <a asp-action="Index"
-       asp-route-fullName="@ViewData["FullName"]"
-       asp-route-hourlyRate="@ViewData["HourlyRate"]"
-       asp-route-statusFilter="@selectedStatus"
-       asp-route-sortBy="id"
-       asp-route-sortDirection="@nextIdDirection"
-       class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
-        Сортувати за датою внесення
-        @if (currentSortBy == "id")
-        {
-            <span>@(currentSortDirection == "desc" ? "↓" : "↑")</span>
-        }
-    </a>
-</div>
+    <div class="app-controls-grid">
+        <section class="app-control-card" aria-label="Фільтри виконавців">
+            <h2 class="app-control-card-title">Фільтри</h2>
+            <form method="get" class="app-filters-form">
+                <input type="hidden" name="sortBy" value="@currentSortBy" />
+                <input type="hidden" name="sortDirection" value="@currentSortDirection" />
+                <div class="app-form-field--wide">
+                    <input type="text" name="fullName" value="@ViewData["FullName"]" class="form-control" placeholder="Пошук за ПІБ" />
+                </div>
+                <div class="app-form-field">
+                    <input type="text" name="hourlyRate" value="@ViewData["HourlyRate"]" class="form-control" placeholder="Пошук за ставкою" inputmode="numeric" pattern="[0-9]+" />
+                </div>
+                <div class="app-form-field">
+                    <select name="statusFilter" class="form-select">
+                        <option value="all" selected="@(selectedStatus == "all" ? "selected" : null)">Усі</option>
+                        <option value="working" selected="@(selectedStatus == "working" ? "selected" : null)">Працює</option>
+                        <option value="dismissed" selected="@(selectedStatus == "dismissed" ? "selected" : null)">Звільнений</option>
+                    </select>
+                </div>
+                <div class="app-form-field">
+                    <button type="submit" class="btn btn-primary w-100">Пошук</button>
+                </div>
+                <div class="app-form-field">
+                    <a asp-action="Index" class="btn btn-secondary w-100">Скинути</a>
+                </div>
+            </form>
+        </section>
 
-<a asp-action="Create" class="btn btn-success mb-2">Додати Виконавця</a>
+        <section class="app-control-card" aria-label="Сортування виконавців">
+            <h2 class="app-control-card-title">Сортування</h2>
+            <div class="app-sort-buttons">
+                <a asp-action="Index"
+                   asp-route-fullName="@ViewData["FullName"]"
+                   asp-route-hourlyRate="@ViewData["HourlyRate"]"
+                   asp-route-statusFilter="@selectedStatus"
+                   asp-route-sortBy="name"
+                   asp-route-sortDirection="@nextNameDirection"
+                   class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">
+                    Сортувати за ПІБ @(currentSortBy == "name" ? (currentSortDirection == "asc" ? "↑" : "↓") : "")
+                </a>
+                <a asp-action="Index"
+                   asp-route-fullName="@ViewData["FullName"]"
+                   asp-route-hourlyRate="@ViewData["HourlyRate"]"
+                   asp-route-statusFilter="@selectedStatus"
+                   asp-route-sortBy="id"
+                   asp-route-sortDirection="@nextIdDirection"
+                   class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
+                    Сортувати за датою внесення @(currentSortBy == "id" ? (currentSortDirection == "desc" ? "↓" : "↑") : "")
+                </a>
+            </div>
+        </section>
+    </div>
 
-<div class="app-table-wrap">
-    <table class="table table-striped app-table">
-        <thead>
-            <tr>
-                <th>ПІБ</th>
-                <th>Ставка/год</th>
-                <th>Email</th>
-                <th>Недоступний</th>
-                <th>Звільнений з дати</th>
-                <th>Дії</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var executor in Model)
-            {
-                <tr>
-                    <td>@executor.FullName</td>
-                    <td>@executor.HourlyRate.ToString("0")</td>
-                    <td>@executor.Email</td>
-                    <td>
-                        @if (executor.UnavailableFrom.HasValue && executor.UnavailableTo.HasValue)
-                        {
-                            @($"{executor.UnavailableFrom:dd.MM.yyyy} - {executor.UnavailableTo:dd.MM.yyyy}")
-                        }
-                    </td>
-                    <td>@executor.DismissedFrom?.ToString("dd.MM.yyyy")</td>
-                    <td>
-                        <div class="app-table-actions">
-                            <a asp-action="Edit" asp-route-id="@executor.ExecutorId" class="btn btn-primary btn-sm">Редагувати</a>
-                            <a asp-action="Delete" asp-route-id="@executor.ExecutorId" class="btn btn-danger btn-sm">Видалити</a>
-                        </div>
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
-</div>
+    <section class="app-table-card">
+        <div class="app-table-wrap">
+            <table class="table table-striped app-table mb-0">
+                <thead>
+                    <tr>
+                        <th>ПІБ</th>
+                        <th>Ставка/год</th>
+                        <th>Email</th>
+                        <th>Недоступний</th>
+                        <th>Звільнений з дати</th>
+                        <th class="app-cell-actions">Дії</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var executor in Model)
+                    {
+                        <tr>
+                            <td>@executor.FullName</td>
+                            <td>@executor.HourlyRate.ToString("0")</td>
+                            <td>@executor.Email</td>
+                            <td>
+                                @if (executor.UnavailableFrom.HasValue && executor.UnavailableTo.HasValue)
+                                {
+                                    @($"{executor.UnavailableFrom:dd.MM.yyyy} - {executor.UnavailableTo:dd.MM.yyyy}")
+                                }
+                            </td>
+                            <td>@executor.DismissedFrom?.ToString("dd.MM.yyyy")</td>
+                            <td class="app-cell-actions">
+                                <div class="app-table-actions">
+                                    <a asp-action="Edit" asp-route-id="@executor.ExecutorId" class="btn btn-primary btn-sm">Редагувати</a>
+                                    <a asp-action="Delete" asp-route-id="@executor.ExecutorId" class="btn btn-danger btn-sm">Видалити</a>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </section>
+</section>

--- a/ClientsApp/Views/ExecutorTask/Create.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Create.cshtml
@@ -4,53 +4,56 @@
     var executors = ViewBag.Executors as IEnumerable<ClientsApp.Models.Entities.Executor>;
 }
 
-<h2>Додати запис</h2>
-
-<form asp-action="Create" method="post">
-    <div class="form-group">
-        <label asp-for="ExecutorId"></label>
-        <select asp-for="ExecutorId" class="form-control" id="ExecutorId">
-            <option value="">-- Виберіть виконавця --</option>
-            @foreach (var ex in executors)
-            {
-                <option value="@ex.ExecutorId" data-rate="@ex.HourlyRate">
-                    @ex.FullName
-                </option>
-            }
-        </select>
-        <span asp-validation-for="ExecutorId" class="text-danger"></span>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">Додати запис</h1>
+        <form asp-action="Create" method="post" class="app-form">
+            <div class="app-form-group">
+                <label asp-for="ExecutorId" class="app-form-label"></label>
+                <select asp-for="ExecutorId" class="form-select app-form-input" id="ExecutorId">
+                    <option value="">-- Виберіть виконавця --</option>
+                    @foreach (var ex in executors)
+                    {
+                        <option value="@ex.ExecutorId" data-rate="@ex.HourlyRate">@ex.FullName</option>
+                    }
+                </select>
+                <span asp-validation-for="ExecutorId" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="ClientId" class="app-form-label"></label>
+                <select asp-for="ClientId" class="form-select app-form-input" asp-items="ViewBag.Clients" id="ClientId">
+                    <option value="">-- Виберіть клієнта --</option>
+                </select>
+                <span asp-validation-for="ClientId" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="ClientTaskId" class="app-form-label"></label>
+                <select asp-for="ClientTaskId" class="form-select app-form-input" asp-items="ViewBag.Tasks" id="ClientTaskId">
+                    <option value="">-- Виберіть завдання --</option>
+                </select>
+                <span asp-validation-for="ClientTaskId" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="ActualTime" class="app-form-label"></label>
+                <input asp-for="ActualTime" class="form-control app-form-input" />
+                <span asp-validation-for="ActualTime" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="AdjustedTime" class="app-form-label"></label>
+                <input asp-for="AdjustedTime" class="form-control app-form-input" id="AdjustedTime" />
+                <span asp-validation-for="AdjustedTime" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label class="app-form-label">Вартість</label>
+                <input id="TaskCost" class="form-control app-form-input" readonly />
+            </div>
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-    <div class="form-group">
-        <label asp-for="ClientId"></label>
-        <select asp-for="ClientId" class="form-control" asp-items="ViewBag.Clients" id="ClientId">
-            <option value="">-- Виберіть клієнта --</option>
-        </select>
-        <span asp-validation-for="ClientId" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="ClientTaskId"></label>
-        <select asp-for="ClientTaskId" class="form-control" asp-items="ViewBag.Tasks" id="ClientTaskId">
-            <option value="">-- Виберіть завдання --</option>
-        </select>
-        <span asp-validation-for="ClientTaskId" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="ActualTime"></label>
-        <input asp-for="ActualTime" class="form-control" />
-        <span asp-validation-for="ActualTime" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="AdjustedTime"></label>
-        <input asp-for="AdjustedTime" class="form-control" id="AdjustedTime" />
-        <span asp-validation-for="AdjustedTime" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label>Вартість</label>
-        <input id="TaskCost" class="form-control" readonly />
-    </div>
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>
 
 @section Scripts{
 <script>

--- a/ClientsApp/Views/ExecutorTask/Edit.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Edit.cshtml
@@ -7,65 +7,62 @@
     int currentClientId = ViewBag.CurrentClientId ?? 0;
 }
 
-<h2>Редагувати запис</h2>
-
-<form asp-action="Edit" method="post">
-    <input type="hidden" asp-for="ExecutorTaskId" />
-    <div class="form-group">
-        <label for="ExecutorId">Виконавець</label>
-        <select id="ExecutorId" name="ExecutorId" class="form-control">
-            <option value="">-- Виберіть виконавця --</option>
-            @foreach (var ex in executors)
-            {
-                <option value="@ex.ExecutorId"
-                        data-rate="@ex.HourlyRate"
-                        selected="@(ex.ExecutorId == Model.ExecutorId)">
-                    @ex.FullName
-                </option>
-            }
-        </select>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">Редагувати запис</h1>
+        <form asp-action="Edit" method="post" class="app-form">
+            <input type="hidden" asp-for="ExecutorTaskId" />
+            <div class="app-form-group">
+                <label for="ExecutorId" class="app-form-label">Виконавець</label>
+                <select id="ExecutorId" name="ExecutorId" class="form-select app-form-input">
+                    <option value="">-- Виберіть виконавця --</option>
+                    @foreach (var ex in executors)
+                    {
+                        <option value="@ex.ExecutorId" data-rate="@ex.HourlyRate" selected="@(ex.ExecutorId == Model.ExecutorId)">@ex.FullName</option>
+                    }
+                </select>
+            </div>
+            <div class="app-form-group">
+                <label for="ClientId" class="app-form-label">Клієнт</label>
+                <select id="ClientId" name="ClientId" class="form-select app-form-input">
+                    <option value="">-- Виберіть клієнта --</option>
+                    @foreach (var cl in clients)
+                    {
+                        <option value="@cl.ClientId" selected="@(cl.ClientId == currentClientId)">@cl.Name</option>
+                    }
+                </select>
+            </div>
+            <div class="app-form-group">
+                <label for="ClientTaskId" class="app-form-label">Завдання</label>
+                <select id="ClientTaskId" name="ClientTaskId" class="form-select app-form-input">
+                    <option value="">-- Виберіть завдання --</option>
+                    @foreach (var t in tasks)
+                    {
+                        <option value="@t.ClientTaskId" selected="@(t.ClientTaskId == Model.ClientTaskId)">@t.TaskTitle</option>
+                    }
+                </select>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="ActualTime" class="app-form-label"></label>
+                <input asp-for="ActualTime" class="form-control app-form-input" />
+                <span asp-validation-for="ActualTime" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="AdjustedTime" class="app-form-label"></label>
+                <input asp-for="AdjustedTime" class="form-control app-form-input" id="AdjustedTime" />
+                <span asp-validation-for="AdjustedTime" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label class="app-form-label">Вартість</label>
+                <input id="TaskCost" class="form-control app-form-input" value="@Model.TaskCost.ToString("F2")" readonly />
+            </div>
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-    <div class="form-group">
-        <label for="ClientId">Клієнт</label>
-        <select id="ClientId" name="ClientId" class="form-control">
-            <option value="">-- Виберіть клієнта --</option>
-            @foreach (var cl in clients)
-            {
-                <option value="@cl.ClientId" selected="@(cl.ClientId == currentClientId)">
-                    @cl.Name
-                </option>
-            }
-        </select>
-    </div>
-    <div class="form-group">
-        <label for="ClientTaskId">Завдання</label>
-        <select id="ClientTaskId" name="ClientTaskId" class="form-control">
-            <option value="">-- Виберіть завдання --</option>
-            @foreach (var t in tasks)
-            {
-                <option value="@t.ClientTaskId" selected="@(t.ClientTaskId == Model.ClientTaskId)">
-                    @t.TaskTitle
-                </option>
-            }
-        </select>
-    </div>
-    <div class="form-group">
-        <label asp-for="ActualTime"></label>
-        <input asp-for="ActualTime" class="form-control" />
-        <span asp-validation-for="ActualTime" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="AdjustedTime"></label>
-        <input asp-for="AdjustedTime" class="form-control" id="AdjustedTime" />
-        <span asp-validation-for="AdjustedTime" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label>Вартість</label>
-        <input id="TaskCost" class="form-control" value="@Model.TaskCost.ToString("F2")" readonly />
-    </div>
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>
 
 @section Scripts{
 <script>

--- a/ClientsApp/Views/ExecutorTask/EditActualTime.cshtml
+++ b/ClientsApp/Views/ExecutorTask/EditActualTime.cshtml
@@ -4,37 +4,37 @@
     ViewData["Title"] = "Редагування фактичного часу";
 }
 
-<h1>Редагування фактичного часу</h1>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">Редагування фактичного часу</h1>
 
-<h4>Завдання виконавця</h4>
-<hr />
-<div class="row">
-    <div class="col-md-6">
-        <form asp-action="Edit" method="post">
+        <form asp-action="Edit" method="post" class="app-form">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="ExecutorTaskId" />
 
-            <div class="mb-3">
-                <label class="form-label">Виконавець</label>
-                <input class="form-control" value="@Model.Executor?.FullName" readonly />
+            <div class="app-form-group">
+                <label class="app-form-label">Виконавець</label>
+                <input class="form-control app-form-input" value="@Model.Executor?.FullName" readonly />
             </div>
 
-            <div class="mb-3">
-                <label class="form-label">Завдання</label>
-                <input class="form-control" value="@Model.ClientTask?.TaskTitle" readonly />
+            <div class="app-form-group">
+                <label class="app-form-label">Завдання</label>
+                <input class="form-control app-form-input" value="@Model.ClientTask?.TaskTitle" readonly />
             </div>
 
-            <div class="mb-3">
-                <label asp-for="ActualTime" class="form-label"></label>
-                <input asp-for="ActualTime" class="form-control" />
+            <div class="app-form-group">
+                <label asp-for="ActualTime" class="app-form-label"></label>
+                <input asp-for="ActualTime" class="form-control app-form-input" />
                 <span asp-validation-for="ActualTime" class="text-danger"></span>
             </div>
 
-            <button type="submit" class="btn btn-primary">Зберегти</button>
-            <a asp-controller="Home" asp-action="Index" class="btn btn-secondary">Назад</a>
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-primary">Зберегти</button>
+                <a asp-controller="Home" asp-action="Index" class="btn btn-secondary">Назад</a>
+            </div>
         </form>
     </div>
-</div>
+</section>
 
 @section Scripts {
     @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }

--- a/ClientsApp/Views/ExecutorTask/Index.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Index.cshtml
@@ -4,83 +4,94 @@
     ViewData["MainContentClass"] = "app-main-content--wide";
 }
 
-<h2>@ViewData["Title"]</h2>
-
-<p>На цій сторінці Облік робочого часу Виконавці завдань ведуть облік робочого часу, витрачено на виконання завдань клієнтів. </p>
-<p>Тут Ви можете отримати усю інформацію по витратах робочого часу по усіх завданнях клієнтів,  а також додавати інформацію про нові завдання та витрати робочого часу, редагувати інформацію та видаляти її. </p>
-<p>Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів. </p>
-<p>Розрахунок вартості послуг з виконання завдання здійснюється автоматично відповідно по ставок оплат відповідного виконавця. </p>
-
-<form method="get" class="row g-3 mb-3">
-    <div class="col-md-3">
-        <select name="executorId" class="form-select">
-            <option value="">Всі виконавці</option>
-            @foreach (var e in (SelectList)ViewBag.Executors)
-            {
-                <option value="@e.Value" selected="@(e.Selected ? "selected" : null)">@e.Text</option>
-            }
-        </select>
+<section class="app-page">
+    <div class="app-page-header">
+        <h1 class="app-page-title">@ViewData["Title"]</h1>
+        <p class="app-page-description">На цій сторінці Облік робочого часу Виконавці завдань ведуть облік робочого часу, витрачено на виконання завдань клієнтів.</p>
+        <p class="app-page-description">Тут Ви можете отримати усю інформацію по витратах робочого часу по усіх завданнях клієнтів,  а також додавати інформацію про нові завдання та витрати робочого часу, редагувати інформацію та видаляти її.</p>
+        <p class="app-page-description">Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів.</p>
+        <p class="app-page-description">Розрахунок вартості послуг з виконання завдання здійснюється автоматично відповідно по ставок оплат відповідного виконавця.</p>
+        <div class="app-page-actions">
+            <a asp-action="Create" class="btn btn-success app-primary-action">Додати запис</a>
+        </div>
     </div>
-    <div class="col-md-3">
-        <select name="clientId" class="form-select">
-            <option value="">Всі клієнти</option>
-            @foreach (var c in (SelectList)ViewBag.Clients)
-            {
-                <option value="@c.Value" selected="@(c.Selected ? "selected" : null)">@c.Text</option>
-            }
-        </select>
-    </div>
-    <div class="col-md-3">
-        <select name="taskId" class="form-select">
-            <option value="">Всі завдання</option>
-            @foreach (var t in (SelectList)ViewBag.Tasks)
-            {
-                <option value="@t.Value" selected="@(t.Selected ? "selected" : null)">@t.Text</option>
-            }
-        </select>
-    </div>
-    <div class="col-md-3 d-flex align-items-end">
-        <button type="submit" class="btn btn-primary me-2">Фільтрувати</button>
-        <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути усі фільтри</a>
-    </div>
-</form>
 
-<a asp-action="Create" class="btn btn-success mb-2">Додати запис</a>
+    <section class="app-control-card" aria-label="Фільтри обліку часу">
+        <h2 class="app-control-card-title">Фільтри</h2>
+        <form method="get" class="app-filters-form">
+            <div class="app-form-field">
+                <select name="executorId" class="form-select">
+                    <option value="">Всі виконавці</option>
+                    @foreach (var e in (SelectList)ViewBag.Executors)
+                    {
+                        <option value="@e.Value" selected="@(e.Selected ? "selected" : null)">@e.Text</option>
+                    }
+                </select>
+            </div>
+            <div class="app-form-field">
+                <select name="clientId" class="form-select">
+                    <option value="">Всі клієнти</option>
+                    @foreach (var c in (SelectList)ViewBag.Clients)
+                    {
+                        <option value="@c.Value" selected="@(c.Selected ? "selected" : null)">@c.Text</option>
+                    }
+                </select>
+            </div>
+            <div class="app-form-field">
+                <select name="taskId" class="form-select">
+                    <option value="">Всі завдання</option>
+                    @foreach (var t in (SelectList)ViewBag.Tasks)
+                    {
+                        <option value="@t.Value" selected="@(t.Selected ? "selected" : null)">@t.Text</option>
+                    }
+                </select>
+            </div>
+            <div class="app-form-field">
+                <button type="submit" class="btn btn-primary w-100">Фільтрувати</button>
+            </div>
+            <div class="app-form-field">
+                <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути усі фільтри</a>
+            </div>
+        </form>
+    </section>
 
-<div class="app-table-wrap">
-    <table class="table table-striped app-table app-table--wide">
-        <thead>
-            <tr>
-                <th>Виконавець</th>
-                <th>Клієнт</th>
-                <th>Завдання</th>
-                <th>Фактичний час</th>
-                <th>Скоригований час</th>
-                <th>Вартість</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-        @foreach (var item in Model)
-        {
-            <tr>
-                <td>@item.Executor?.FullName</td>
-                <td>@item.ClientTask?.Client?.Name</td>
-                <td>@item.ClientTask?.TaskTitle</td>
-                <td>@item.ActualTime</td>
-                <td>@item.AdjustedTime</td>
-                <td>@item.TaskCost.ToString("F2")</td>
-                <td>
-                    <div class="app-table-actions">
-                        <a asp-action="Edit" asp-route-id="@item.ExecutorTaskId" class="btn btn-primary btn-sm">Редагувати</a>
-                        <a asp-action="Delete" asp-route-id="@item.ExecutorTaskId" class="btn btn-danger btn-sm">Видалити</a>
-                    </div>
-                </td>
-            </tr>
-        }
-        </tbody>
-    </table>
-</div>
+    <section class="app-table-card">
+        <div class="app-table-wrap">
+            <table class="table table-striped app-table app-table--wide mb-0">
+                <thead>
+                    <tr>
+                        <th>Виконавець</th>
+                        <th>Клієнт</th>
+                        <th>Завдання</th>
+                        <th>Фактичний час</th>
+                        <th>Скоригований час</th>
+                        <th>Вартість</th>
+                        <th class="app-cell-actions">Дії</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td>@item.Executor?.FullName</td>
+                        <td>@item.ClientTask?.Client?.Name</td>
+                        <td>@item.ClientTask?.TaskTitle</td>
+                        <td>@item.ActualTime</td>
+                        <td>@item.AdjustedTime</td>
+                        <td>@item.TaskCost.ToString("F2")</td>
+                        <td class="app-cell-actions">
+                            <div class="app-table-actions">
+                                <a asp-action="Edit" asp-route-id="@item.ExecutorTaskId" class="btn btn-primary btn-sm">Редагувати</a>
+                                <a asp-action="Delete" asp-route-id="@item.ExecutorTaskId" class="btn btn-danger btn-sm">Видалити</a>
+                            </div>
+                        </td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </section>
+</section>
 
 @section Scripts {
     <script>

--- a/ClientsApp/Views/Payment/Create.cshtml
+++ b/ClientsApp/Views/Payment/Create.cshtml
@@ -3,21 +3,27 @@
     ViewData["Title"] = "Додати платіж";
 }
 
-<h2>Додати платіж</h2>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">Додати платіж</h1>
 
-<form asp-action="Create" method="post">
-    <div class="form-group">
-        <label asp-for="ClientTaskId"></label>
-        <select asp-for="ClientTaskId" class="form-control" asp-items="ViewBag.Tasks">
-            <option value="">-- Виберіть завдання --</option>
-        </select>
-        <span asp-validation-for="ClientTaskId" class="text-danger"></span>
+        <form asp-action="Create" method="post" class="app-form">
+            <div class="app-form-group">
+                <label asp-for="ClientTaskId" class="app-form-label"></label>
+                <select asp-for="ClientTaskId" class="form-select app-form-input" asp-items="ViewBag.Tasks">
+                    <option value="">-- Виберіть завдання --</option>
+                </select>
+                <span asp-validation-for="ClientTaskId" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="Amount" class="app-form-label"></label>
+                <input asp-for="Amount" class="form-control app-form-input" />
+                <span asp-validation-for="Amount" class="text-danger"></span>
+            </div>
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-    <div class="form-group">
-        <label asp-for="Amount"></label>
-        <input asp-for="Amount" class="form-control" />
-        <span asp-validation-for="Amount" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>

--- a/ClientsApp/Views/Payment/Edit.cshtml
+++ b/ClientsApp/Views/Payment/Edit.cshtml
@@ -3,25 +3,31 @@
     ViewData["Title"] = "Редагувати платіж";
 }
 
-<h2>Редагувати платіж</h2>
+<section class="app-form-page">
+    <div class="app-form-card">
+        <h1 class="app-form-title">Редагувати платіж</h1>
 
-<form asp-action="Edit" method="post">
-    <input type="hidden" asp-for="PaymentId" />
-    <div class="form-group">
-        <label asp-for="ClientTaskId"></label>
-        <select asp-for="ClientTaskId" class="form-control" asp-items="ViewBag.Tasks"></select>
-        <span asp-validation-for="ClientTaskId" class="text-danger"></span>
+        <form asp-action="Edit" method="post" class="app-form">
+            <input type="hidden" asp-for="PaymentId" />
+            <div class="app-form-group">
+                <label asp-for="ClientTaskId" class="app-form-label"></label>
+                <select asp-for="ClientTaskId" class="form-select app-form-input" asp-items="ViewBag.Tasks"></select>
+                <span asp-validation-for="ClientTaskId" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="Amount" class="app-form-label"></label>
+                <input asp-for="Amount" class="form-control app-form-input" />
+                <span asp-validation-for="Amount" class="text-danger"></span>
+            </div>
+            <div class="app-form-group">
+                <label asp-for="PaymentDate" class="app-form-label"></label>
+                <input asp-for="PaymentDate" class="form-control app-form-input" type="date" />
+                <span asp-validation-for="PaymentDate" class="text-danger"></span>
+            </div>
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Зберегти</button>
+                <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
+            </div>
+        </form>
     </div>
-    <div class="form-group">
-        <label asp-for="Amount"></label>
-        <input asp-for="Amount" class="form-control" />
-        <span asp-validation-for="Amount" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="PaymentDate"></label>
-        <input asp-for="PaymentDate" class="form-control" type="date" />
-        <span asp-validation-for="PaymentDate" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-success">Зберегти</button>
-    <a asp-action="Index" class="btn btn-secondary">Скасувати</a>
-</form>
+</section>

--- a/ClientsApp/Views/Payment/Index.cshtml
+++ b/ClientsApp/Views/Payment/Index.cshtml
@@ -1,60 +1,70 @@
 @model ClientsApp.Models.ViewModels.PaymentIndexViewModel
 @{
     ViewData["Title"] = "Оплати";
-    ViewData["MainContentClass"] = "app-main-content--wide";
 }
 
-<h2>@ViewData["Title"]</h2>
-<p>На цій сторінці Оплати Ви можете отримати усю інформацію по усіх оплатах завдань клієнтів,  а також додавати інформацію про оплати. </p>
-<p>Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів. </p>
-
-
-<form method="get" class="row g-3 mb-3">
-    <div class="col-md-4">
-        <select asp-for="SelectedClientId" asp-items="Model.Clients" class="form-select">
-            <option value="">Всі клієнти</option>
-        </select>
+<section class="app-page">
+    <div class="app-page-header">
+        <h1 class="app-page-title">@ViewData["Title"]</h1>
+        <p class="app-page-description">На цій сторінці Оплати Ви можете отримати усю інформацію по усіх оплатах завдань клієнтів,  а також додавати інформацію про оплати.</p>
+        <p class="app-page-description">Ви можете здійснювати фільтрацію у зручному для Вас форматі відповідно до обраних фільтрів.</p>
+        <div class="app-page-actions">
+            <a asp-action="Create" class="btn btn-success app-primary-action">Додати платіж</a>
+        </div>
     </div>
-    <div class="col-md-4">
-        <select asp-for="IsPaid" class="form-select">
-            <option value="">Всі</option>
-            <option value="true">Оплачені</option>
-            <option value="false">Неоплачені</option>
-        </select>
-    </div>
-    <div class="col-md-4 d-flex align-items-end">
-        <button type="submit" class="btn btn-primary me-2">Фільтрувати</button>
-        <a asp-action="Index" class="btn btn-secondary" id="resetFilters">Скинути усі фільтри</a>
-    </div>
-</form>
 
-<a asp-action="Create" class="btn btn-success mb-2">Додати платіж</a>
+    <section class="app-control-card">
+        <h2 class="app-control-card-title">Фільтри</h2>
+        <form method="get" class="app-filters-form">
+            <div class="app-form-field app-form-field--wide">
+                <select asp-for="SelectedClientId" asp-items="Model.Clients" class="form-select">
+                    <option value="">Всі клієнти</option>
+                </select>
+            </div>
+            <div class="app-form-field app-form-field--wide">
+                <select asp-for="IsPaid" class="form-select">
+                    <option value="">Всі</option>
+                    <option value="true">Оплачені</option>
+                    <option value="false">Неоплачені</option>
+                </select>
+            </div>
+            <div class="app-form-field">
+                <button type="submit" class="btn btn-primary w-100">Фільтрувати</button>
+            </div>
+            <div class="app-form-field">
+                <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути усі фільтри</a>
+            </div>
+        </form>
+    </section>
 
-<div class="app-table-wrap">
-    <table class="table table-striped app-table">
-        <thead>
-            <tr>
-                <th>Клієнт</th>
-                <th>Завдання</th>
-                <th>Вартість послуг</th>
-                <th>Оплачено</th>
-                <th>Заборгованість</th>
-            </tr>
-        </thead>
-        <tbody>
-        @foreach (var p in Model.Payments)
-        {
-            <tr>
-                <td>@p.ClientName</td>
-                <td>@p.TaskTitle</td>
-                <td>@p.ServiceCost.ToString("F2")</td>
-                <td>@p.AmountReceived.ToString("F2")</td>
-                <td>@p.BalanceDue.ToString("F2")</td>
-            </tr>
-        }
-        </tbody>
-    </table>
-</div>
+    <section class="app-table-card">
+        <div class="app-table-wrap">
+            <table class="table table-striped app-table mb-0">
+                <thead>
+                    <tr>
+                        <th>Клієнт</th>
+                        <th>Завдання</th>
+                        <th>Вартість послуг</th>
+                        <th>Оплачено</th>
+                        <th>Заборгованість</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var p in Model.Payments)
+                {
+                    <tr>
+                        <td>@p.ClientName</td>
+                        <td>@p.TaskTitle</td>
+                        <td>@p.ServiceCost.ToString("F2")</td>
+                        <td>@p.AmountReceived.ToString("F2")</td>
+                        <td>@p.BalanceDue.ToString("F2")</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </section>
+</section>
 
 @section Scripts {
     <script>

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -809,3 +809,269 @@ a {
         width: 100%;
     }
 }
+
+/* Shared CRUD/List UI system */
+.app-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.app-page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    padding-top: 0.35rem;
+}
+
+.app-page-title {
+    margin: 0;
+    font-size: clamp(1.75rem, 2.9vw, 2.25rem);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.01em;
+    color: #10253f;
+}
+
+.app-page-description {
+    margin: 0;
+    max-width: 920px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.app-page-actions {
+    margin-top: 0.35rem;
+}
+
+.app-primary-action {
+    min-height: 42px;
+    border-radius: 10px;
+    padding: 0.52rem 1rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-primary-action:hover,
+.app-primary-action:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba(22, 103, 57, 0.2);
+}
+
+.app-controls-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.app-section-card,
+.app-control-card,
+.app-table-card,
+.app-form-card {
+    background: var(--card-bg);
+    border: 1px solid rgba(17, 36, 63, 0.05);
+    border-radius: 12px;
+    box-shadow: 0 10px 24px rgba(20, 49, 89, 0.08);
+}
+
+.app-control-card,
+.app-table-card {
+    padding: 1.25rem;
+}
+
+.app-control-card-title {
+    margin: 0 0 1rem;
+    color: #163156;
+    font-size: 1.06rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.app-filters-form {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 0.75rem;
+    align-items: end;
+}
+
+.app-form-field {
+    grid-column: span 3;
+    min-width: 0;
+}
+
+.app-form-field--wide {
+    grid-column: span 6;
+}
+
+.app-filters-form .form-control,
+.app-filters-form .form-select,
+.app-form-input {
+    min-height: 42px;
+    border-radius: 10px;
+    border: 1px solid rgba(44, 86, 139, 0.2);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.app-filters-form .form-control:focus,
+.app-filters-form .form-select:focus,
+.app-form-input:focus {
+    border-color: rgba(47, 95, 155, 0.45);
+    box-shadow: 0 0 0 0.2rem rgba(58, 130, 246, 0.16);
+    background-color: #ffffff;
+}
+
+.app-filters-form .btn,
+.app-sort-buttons .btn {
+    min-height: 42px;
+    border-radius: 10px;
+    font-weight: 600;
+}
+
+.app-sort-buttons {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.app-sort-buttons .btn {
+    width: 100%;
+    padding: 0.5rem 0.68rem;
+    font-size: 0.9rem;
+}
+
+.app-table-card {
+    margin-top: 0.25rem;
+}
+
+.app-table-wrap {
+    border-radius: 10px;
+}
+
+.app-table > tbody > tr > td {
+    max-width: 250px;
+}
+
+.app-table--wide > tbody > tr > td,
+.app-table--wide > thead > tr > th {
+    white-space: nowrap;
+}
+
+.app-table--wide > tbody > tr > td {
+    max-width: 300px;
+}
+
+.app-table td.app-cell-actions,
+.app-table th.app-cell-actions {
+    min-width: 220px;
+}
+
+.app-form-page {
+    display: flex;
+    justify-content: center;
+    padding: 0.3rem 0 1rem;
+}
+
+.app-form-card {
+    width: min(100%, 760px);
+    padding: 1.5rem;
+}
+
+.app-form-title {
+    margin: 0 0 1.1rem;
+    font-size: clamp(1.65rem, 2.8vw, 2rem);
+    font-weight: 700;
+    color: #10253f;
+    letter-spacing: -0.01em;
+}
+
+.app-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.95rem;
+}
+
+.app-form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.app-form-label {
+    margin: 0;
+    font-weight: 600;
+    color: #1d3a5f;
+}
+
+.app-form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.3rem;
+}
+
+.app-form-actions .btn {
+    min-height: 42px;
+    border-radius: 10px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+}
+
+@media (max-width: 991.98px) {
+    .app-controls-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .app-form-field,
+    .app-form-field--wide {
+        grid-column: span 6;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .app-control-card,
+    .app-table-card,
+    .app-form-card {
+        padding: 1rem;
+    }
+
+    .app-filters-form,
+    .app-sort-buttons {
+        grid-template-columns: 1fr;
+    }
+
+    .app-form-field,
+    .app-form-field--wide {
+        grid-column: span 1;
+    }
+
+    .app-filters-form .btn,
+    .app-sort-buttons .btn,
+    .app-form-actions .btn {
+        width: 100%;
+    }
+
+    .app-form-actions {
+        flex-direction: column;
+    }
+}
+
+.app-sort-buttons .sort-label-with-icon {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.app-sort-buttons .sort-arrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+}
+
+.app-sort-buttons .sort-arrow.is-asc {
+    transform: rotate(180deg);
+}


### PR DESCRIPTION
### Motivation
- Provide a single, modern SaaS/admin visual system for all standard CRUD pages so the app feels consistent while keeping all existing business logic and flows intact. 
- Apply the same layout rhythm, control cards, primary action, table card, action-cell and form system to list and create/edit pages for the main entities.
- Keep wide layout behavior for wide tables (Tasks / Time Tracking) and do not touch the Statistics/Reports page in this pass.

### Description
- Added a shared design system in `wwwroot/css/site.css` with reusable classes such as `app-page`, `app-page-header`, `app-controls-grid`, `app-control-card`, `app-table-card`, `app-table`, `app-table--wide`, `app-table-actions`, `app-form-page`, `app-form-card`, `app-form-*`, and sort icon helpers to unify spacing, radii, shadows and responsive rules. 
- Updated list views to the shared layout structure (header + description + primary action + controls card(s) + table card) for `Clients`, `Executors`, `ClientTask (Tasks)`, `ExecutorTask (Time Tracking)` and `Payments`; tables now use the global `app-table` and action cells use `app-table-actions` and `app-cell-actions` where applicable. 
- Converted create/edit pages for Clients, Executors, Tasks, Time Tracking and Payments to the centered card form pattern using `app-form-page`, `app-form-card`, `app-form-title`, `app-form-group`, `app-form-label`, `app-form-input` and `app-form-actions` while preserving all existing fields, validations and scripts. 
- Preserved functional behavior: all routes, filter inputs, sort links, CRUD actions, inline scripts and server-side view model bindings remain unchanged except for markup class refactors; Tasks and Time Tracking continue to use the wider content variant via `app-main-content--wide` where previously set.

### Testing
- Attempted an automated build with `dotnet build ClientsApp.sln`, but the runtime/tooling is not available in this environment so the build could not be executed (no `dotnet` present). 
- Verified the updated CSS and Razor files were written to disk and inspected view templates to ensure original inputs, forms, filters, sort links and scripts were preserved and only visual classes/structure were changed; no runtime logic was modified. 
- Responsive and visual rules were added to `site.css` with mobile/tablet/desktop breakpoints to match the existing homepage system and the refined table/button styles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7658f47648328a1a1e524aa692333)