### PR TITLE
Align account pages with shared form styling system

### DIFF
--- a/ClientsApp/Views/Account/Profile.cshtml
+++ b/ClientsApp/Views/Account/Profile.cshtml
@@ -3,72 +3,72 @@
     ViewData["Title"] = "Мій профіль";
 }
 
-<h2>Мій профіль</h2>
+<section class="app-form-page" aria-labelledby="profile-title">
+    <div class="container px-0">
+        <h1 id="profile-title" class="app-form-title">Мій профіль</h1>
 
-@if (TempData["SuccessMessage"] is string successMessage)
-{
-    <div class="alert alert-success" role="alert">
-        @successMessage
-    </div>
-}
+        @if (TempData["SuccessMessage"] is string successMessage)
+        {
+            <div class="alert alert-success" role="alert">
+                @successMessage
+            </div>
+        }
 
-<div class="row g-4 mt-1">
-    <div class="col-12 col-lg-6">
-        <div class="card">
-            <div class="card-body">
-                <h5 class="card-title">Зміна email</h5>
+        <div class="app-controls-grid">
+            <div class="app-form-card">
+                <h2 class="app-control-card-title">Зміна email</h2>
 
-                <form asp-action="UpdateEmail" method="post" class="mt-3">
+                <form asp-action="UpdateEmail" method="post" class="app-form" novalidate>
                     @Html.AntiForgeryToken()
 
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-                    <div class="mb-3">
-                        <label asp-for="UpdateEmail.NewEmail" class="form-label"></label>
-                        <input asp-for="UpdateEmail.NewEmail" class="form-control" />
+                    <div class="app-form-group">
+                        <label asp-for="UpdateEmail.NewEmail" class="app-form-label"></label>
+                        <input asp-for="UpdateEmail.NewEmail" class="form-control app-form-input" />
                         <span asp-validation-for="UpdateEmail.NewEmail" class="text-danger"></span>
                     </div>
 
-                    <button type="submit" class="btn btn-primary">Змінити email</button>
+                    <div class="app-form-actions">
+                        <button type="submit" class="btn btn-success">Змінити email</button>
+                    </div>
                 </form>
             </div>
-        </div>
-    </div>
 
-    <div class="col-12 col-lg-6">
-        <div class="card">
-            <div class="card-body">
-                <h5 class="card-title">Зміна пароля</h5>
+            <div class="app-form-card">
+                <h2 class="app-control-card-title">Зміна пароля</h2>
 
-                <form asp-action="ChangePassword" method="post" class="mt-3">
+                <form asp-action="ChangePassword" method="post" class="app-form" novalidate>
                     @Html.AntiForgeryToken()
 
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-                    <div class="mb-3">
-                        <label asp-for="ChangePassword.CurrentPassword" class="form-label"></label>
-                        <input asp-for="ChangePassword.CurrentPassword" class="form-control" />
+                    <div class="app-form-group">
+                        <label asp-for="ChangePassword.CurrentPassword" class="app-form-label"></label>
+                        <input asp-for="ChangePassword.CurrentPassword" class="form-control app-form-input" />
                         <span asp-validation-for="ChangePassword.CurrentPassword" class="text-danger"></span>
                     </div>
 
-                    <div class="mb-3">
-                        <label asp-for="ChangePassword.NewPassword" class="form-label"></label>
-                        <input asp-for="ChangePassword.NewPassword" class="form-control" />
+                    <div class="app-form-group">
+                        <label asp-for="ChangePassword.NewPassword" class="app-form-label"></label>
+                        <input asp-for="ChangePassword.NewPassword" class="form-control app-form-input" />
                         <span asp-validation-for="ChangePassword.NewPassword" class="text-danger"></span>
                     </div>
 
-                    <div class="mb-3">
-                        <label asp-for="ChangePassword.ConfirmNewPassword" class="form-label"></label>
-                        <input asp-for="ChangePassword.ConfirmNewPassword" class="form-control" />
+                    <div class="app-form-group">
+                        <label asp-for="ChangePassword.ConfirmNewPassword" class="app-form-label"></label>
+                        <input asp-for="ChangePassword.ConfirmNewPassword" class="form-control app-form-input" />
                         <span asp-validation-for="ChangePassword.ConfirmNewPassword" class="text-danger"></span>
                     </div>
 
-                    <button type="submit" class="btn btn-primary">Змінити пароль</button>
+                    <div class="app-form-actions">
+                        <button type="submit" class="btn btn-success">Змінити пароль</button>
+                    </div>
                 </form>
             </div>
         </div>
     </div>
-</div>
+</section>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/ClientsApp/Views/Account/Register.cshtml
+++ b/ClientsApp/Views/Account/Register.cshtml
@@ -3,44 +3,50 @@
     ViewData["Title"] = "Створення користувача";
 }
 
-<h2>Створення користувача</h2>
+<section class="app-form-page" aria-labelledby="register-user-title">
+    <div class="app-form-card">
+        <h1 id="register-user-title" class="app-form-title">Створення користувача</h1>
 
-<form asp-action="Register" method="post" class="mt-3">
-    @Html.AntiForgeryToken()
-    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <form asp-action="Register" method="post" class="app-form" novalidate>
+            @Html.AntiForgeryToken()
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="Email" class="form-label"></label>
-        <input asp-for="Email" class="form-control" />
-        <span asp-validation-for="Email" class="text-danger"></span>
+            <div class="app-form-group">
+                <label asp-for="Email" class="app-form-label"></label>
+                <input asp-for="Email" class="form-control app-form-input" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="Role" class="app-form-label"></label>
+                <select asp-for="Role" class="form-select app-form-input app-form-select">
+                    <option value="">Оберіть роль</option>
+                    @foreach (var role in (string[])ViewBag.Roles)
+                    {
+                        <option value="@role">@role</option>
+                    }
+                </select>
+                <span asp-validation-for="Role" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="Password" class="app-form-label"></label>
+                <input asp-for="Password" class="form-control app-form-input" />
+                <span asp-validation-for="Password" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-group">
+                <label asp-for="ConfirmPassword" class="app-form-label"></label>
+                <input asp-for="ConfirmPassword" class="form-control app-form-input" />
+                <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+            </div>
+
+            <div class="app-form-actions">
+                <button type="submit" class="btn btn-success">Створити користувача</button>
+            </div>
+        </form>
     </div>
-
-    <div class="mb-3">
-        <label asp-for="Role" class="form-label"></label>
-        <select asp-for="Role" class="form-select">
-            <option value="">Оберіть роль</option>
-            @foreach (var role in (string[])ViewBag.Roles)
-            {
-                <option value="@role">@role</option>
-            }
-        </select>
-        <span asp-validation-for="Role" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Password" class="form-label"></label>
-        <input asp-for="Password" class="form-control" />
-        <span asp-validation-for="Password" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="ConfirmPassword" class="form-label"></label>
-        <input asp-for="ConfirmPassword" class="form-control" />
-        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
-    </div>
-
-    <button type="submit" class="btn btn-primary">Створити користувача</button>
-</form>
+</section>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -930,6 +930,11 @@ a {
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
+.app-form-select {
+    min-height: 42px;
+    border-radius: 10px;
+}
+
 .app-filters-form .form-control:focus,
 .app-filters-form .form-select:focus,
 .app-form-input:focus {


### PR DESCRIPTION
### Motivation
- Bring the Create User and Profile pages into visual parity with the existing shared form system used by Create Client. 
- Replace raw Bootstrap/default form blocks with the app-wide form components to ensure consistent spacing, inputs and buttons.

### Description
- Updated `Account/Register.cshtml` to wrap the page in `app-form-page`/`app-form-card`, convert inputs/labels to `app-form-group`, `app-form-label`, `app-form-input` and move actions into `app-form-actions` using the same primary button style as Create Client.
- Updated `Account/Profile.cshtml` to render the email and password sections each inside their own `app-form-card`, use `app-controls-grid` for responsive two-column layout, and apply `app-form-*` classes for labels, inputs and actions while keeping the forms separate.
- Added a small CSS hook `.app-form-select` to `wwwroot/css/site.css` so selects match the shared input sizing and border-radius.

### Testing
- Attempted to run `dotnet build ClientsApp/ClientsApp.sln` but it could not be executed in this environment (`dotnet: command not found`).
- No automated test suites were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7796ef6548328bcfd3dfd4841ae43)