### PR TITLE
Polish Executors filters and sorting controls to match Clients page

### DIFF
--- a/ClientsApp/Views/Executor/Index.cshtml
+++ b/ClientsApp/Views/Executor/Index.cshtml
@@ -21,34 +21,34 @@
     <div class="app-controls-grid">
         <section class="app-control-card" aria-label="Фільтри виконавців">
             <h2 class="app-control-card-title">Фільтри</h2>
-            <form method="get" class="app-filters-form">
+            <form method="get" class="app-filters-form app-filters-form--executors">
                 <input type="hidden" name="sortBy" value="@currentSortBy" />
                 <input type="hidden" name="sortDirection" value="@currentSortDirection" />
-                <div class="app-form-field--wide">
-                    <input type="text" name="fullName" value="@ViewData["FullName"]" class="form-control" placeholder="Пошук за ПІБ" />
+                <div class="app-form-field app-form-field--name">
+                    <input type="text" name="fullName" value="@ViewData["FullName"]" class="form-control" placeholder="ПІБ" />
                 </div>
-                <div class="app-form-field">
-                    <input type="text" name="hourlyRate" value="@ViewData["HourlyRate"]" class="form-control" placeholder="Пошук за ставкою" inputmode="numeric" pattern="[0-9]+" />
+                <div class="app-form-field app-form-field--rate">
+                    <input type="text" name="hourlyRate" value="@ViewData["HourlyRate"]" class="form-control" placeholder="Ставка" inputmode="numeric" pattern="[0-9]+" />
                 </div>
-                <div class="app-form-field">
+                <div class="app-form-field app-form-field--status">
                     <select name="statusFilter" class="form-select">
                         <option value="all" selected="@(selectedStatus == "all" ? "selected" : null)">Усі</option>
                         <option value="working" selected="@(selectedStatus == "working" ? "selected" : null)">Працює</option>
                         <option value="dismissed" selected="@(selectedStatus == "dismissed" ? "selected" : null)">Звільнений</option>
                     </select>
                 </div>
-                <div class="app-form-field">
+                <div class="app-form-field app-form-field--action">
                     <button type="submit" class="btn btn-primary w-100">Пошук</button>
                 </div>
-                <div class="app-form-field">
-                    <a asp-action="Index" class="btn btn-secondary w-100">Скинути</a>
+                <div class="app-form-field app-form-field--action">
+                    <a asp-action="Index" class="btn btn-outline-secondary w-100">Скинути</a>
                 </div>
             </form>
         </section>
 
         <section class="app-control-card" aria-label="Сортування виконавців">
             <h2 class="app-control-card-title">Сортування</h2>
-            <div class="app-sort-buttons">
+            <div class="app-sort-buttons app-sort-buttons--executors">
                 <a asp-action="Index"
                    asp-route-fullName="@ViewData["FullName"]"
                    asp-route-hourlyRate="@ViewData["HourlyRate"]"

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -962,6 +962,34 @@ a {
     font-size: 0.9rem;
 }
 
+.app-filters-form--executors {
+    row-gap: 0.8rem;
+}
+
+.app-filters-form--executors .app-form-field--name {
+    grid-column: span 5;
+}
+
+.app-filters-form--executors .app-form-field--rate {
+    grid-column: span 4;
+}
+
+.app-filters-form--executors .app-form-field--status {
+    grid-column: span 3;
+}
+
+.app-filters-form--executors .app-form-field--action {
+    grid-column: span 3;
+}
+
+.app-sort-buttons--executors {
+    align-items: center;
+}
+
+.app-sort-buttons--executors .btn {
+    padding-inline: 0.65rem;
+}
+
 .app-table-card {
     margin-top: 0.25rem;
 }
@@ -1048,6 +1076,13 @@ a {
     .app-form-field--wide {
         grid-column: span 6;
     }
+
+    .app-filters-form--executors .app-form-field--name,
+    .app-filters-form--executors .app-form-field--rate,
+    .app-filters-form--executors .app-form-field--status,
+    .app-filters-form--executors .app-form-field--action {
+        grid-column: span 6;
+    }
 }
 
 @media (max-width: 767.98px) {
@@ -1064,6 +1099,13 @@ a {
 
     .app-form-field,
     .app-form-field--wide {
+        grid-column: span 1;
+    }
+
+    .app-filters-form--executors .app-form-field--name,
+    .app-filters-form--executors .app-form-field--rate,
+    .app-filters-form--executors .app-form-field--status,
+    .app-filters-form--executors .app-form-field--action {
         grid-column: span 1;
     }
 


### PR DESCRIPTION
### Motivation
- Improve visual parity between the "Executors" and "Clients" pages by polishing the Filters and Sorting area to match the Clients page card style and spacing while keeping all behavior intact.
- Shorten and simplify filter placeholders for better readability and a more premium, compact layout.

### Description
- Refined the Filters Razor markup in `Views/Executor/Index.cshtml` by adding `app-filters-form--executors` and per-field classes, replacing long placeholders with `ПІБ` and `Ставка`, and keeping all existing form routes and hidden sort fields unchanged.
- Updated the reset control to use the outlined secondary style to match the Clients page button pattern without changing any filter logic or routes.
- Added CSS rules in `wwwroot/css/site.css` to control field proportions (`.app-form-field--name`, `.app-form-field--rate`, `.app-form-field--status`, `.app-form-field--action`), adjust spacing and button padding, and ensure consistent responsive wrapping that mirrors the Clients page visual rhythm.
- Kept the table, page title/description, and the "Додати Виконавця" button untouched, and made no logic/sorting/filtering behavior changes.

### Testing
- Attempted to run `dotnet build ClientsApp.sln`, but the `dotnet` CLI is not available in this environment so the build could not be executed (failed).
- Verified locally in the changed files that markup keeps previous `asp-route-*` bindings and hidden sort inputs untouched via source inspection (no automated build available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77d73449083288dc980cce9ee0d4a)