### PR TITLE
Make Filters visually primary by updating Filters/Sorting shared layout to 2:1

### DIFF
--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -536,7 +536,7 @@ a {
 
 .clients-controls-grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     gap: 1rem;
 }
 
@@ -690,11 +690,15 @@ a {
 
 @media (max-width: 991.98px) {
     .clients-controls-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
     }
 }
 
 @media (max-width: 767.98px) {
+    .clients-controls-grid {
+        grid-template-columns: 1fr;
+    }
+
     .clients-filters-form {
         grid-template-columns: 1fr;
     }
@@ -878,7 +882,7 @@ a {
 
 .app-controls-grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     gap: 1rem;
 }
 
@@ -1069,6 +1073,10 @@ a {
 
 @media (max-width: 991.98px) {
     .app-controls-grid {
+        grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    }
+
+    .app-form-page .app-controls-grid {
         grid-template-columns: 1fr;
     }
 
@@ -1086,6 +1094,10 @@ a {
 }
 
 @media (max-width: 767.98px) {
+    .app-controls-grid {
+        grid-template-columns: 1fr;
+    }
+
     .app-control-card,
     .app-table-card,
     .app-form-card {


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy so Filters are primary and Sorting is secondary without changing behavior or controls.
- Apply a single reusable layout pattern across pages that display Filters and Sorting together to ensure consistent UI balance.
- Preserve existing filter/sort logic and control markup while adjusting only layout and responsive behavior.

### Description
- Change shared grid for control panels by updating `.app-controls-grid` to `grid-template-columns: minmax(0, 2fr) minmax(0, 1fr)` so Filters take ~2/3 and Sorting ~1/3 of horizontal space on desktop.
- Align legacy page-specific grid `.clients-controls-grid` to the same `2fr / 1fr` pattern and add matching responsive rules.
- Add tablet breakpoint behavior using `minmax(0, 1.6fr) minmax(0, 1fr)` to keep Filters wider on medium screens and ensure Blocks stack to a single column on mobile (Filters first, Sorting below).
- Add a scoped override so form/profile pages using `.app-form-page` keep an appropriate single-column layout where necessary and avoid forcing the asymmetric grid on non-filter forms.

### Testing
- Attempted to run `dotnet build ClientsApp.sln` but the environment does not have the `dotnet` SDK installed, so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e780af08b48328aa43e8b6aff01653)