### PR TITLE
Introduce shared 5:1 grid for Filters and Sorting

### DIFF
--- a/ClientsApp/Views/Client/Index.cshtml
+++ b/ClientsApp/Views/Client/Index.cshtml
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    <div class="app-controls-grid">
+    <div class="app-controls-grid app-controls-grid--filters-sort">
         <section class="app-control-card" aria-label="Фільтри клієнтів">
             <h2 class="app-control-card-title">Фільтри</h2>
             <form method="get" class="app-filters-form">

--- a/ClientsApp/Views/ClientTask/Index.cshtml
+++ b/ClientsApp/Views/ClientTask/Index.cshtml
@@ -16,7 +16,7 @@
         </div>
     </div>
 
-    <div class="app-controls-grid">
+    <div class="app-controls-grid app-controls-grid--filters-sort">
         <section class="app-control-card" aria-label="Фільтри завдань">
             <h2 class="app-control-card-title">Фільтри</h2>
             <form asp-action="Index" method="get" class="app-filters-form">

--- a/ClientsApp/Views/Executor/Index.cshtml
+++ b/ClientsApp/Views/Executor/Index.cshtml
@@ -18,7 +18,7 @@
         </div>
     </div>
 
-    <div class="app-controls-grid">
+    <div class="app-controls-grid app-controls-grid--filters-sort">
         <section class="app-control-card" aria-label="Фільтри виконавців">
             <h2 class="app-control-card-title">Фільтри</h2>
             <form method="get" class="app-filters-form app-filters-form--executors">

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -882,8 +882,12 @@ a {
 
 .app-controls-grid {
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     gap: 1rem;
+}
+
+.app-controls-grid--filters-sort {
+    grid-template-columns: minmax(0, 5fr) minmax(0, 1fr);
+    align-items: start;
 }
 
 .app-section-card,
@@ -1072,8 +1076,8 @@ a {
 }
 
 @media (max-width: 991.98px) {
-    .app-controls-grid {
-        grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    .app-controls-grid--filters-sort {
+        grid-template-columns: minmax(0, 4fr) minmax(0, 2fr);
     }
 
     .app-form-page .app-controls-grid {
@@ -1094,7 +1098,7 @@ a {
 }
 
 @media (max-width: 767.98px) {
-    .app-controls-grid {
+    .app-controls-grid--filters-sort {
         grid-template-columns: 1fr;
     }
 


### PR DESCRIPTION
### Motivation
- Make Filters the primary interaction area and reduce the visual weight of Sorting by applying a consistent global layout rule.
- Avoid per-page layout duplication by creating a reusable layout variant for all pages that show both Filters and Sorting.

### Description
- Added a reusable layout class `app-controls-grid--filters-sort` in `ClientsApp/wwwroot/css/site.css` that implements a desktop grid of `5fr 1fr`, aligns items to the top, and preserves consistent gap and card styling.
- Added responsive rules for the new layout: tablet degrades to `4fr 2fr` and mobile stacks to `1fr` while keeping Filters first.
- Applied the new class to all index pages that contain both Filters and Sorting by updating the Razor views `ClientsApp/Views/Client/Index.cshtml`, `ClientsApp/Views/Executor/Index.cshtml`, and `ClientsApp/Views/ClientTask/Index.cshtml` to include `app-controls-grid--filters-sort` alongside `app-controls-grid`.
- This change is layout-only and does not modify filtering/sorting logic, controls, table layouts, or internal block contents.

### Testing
- Located and verified affected pages with `rg` to ensure the layout class is applied where both sections appear, and the search completed successfully.
- Inspected the diff of modified files with `git diff` to confirm only intended CSS and Razor class additions were made and the check succeeded.
- Staged and committed the changes to the repository and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fc3bc5388328975b8e75fb4ba6cc)