### PR TITLE
Simplify sorting blocks to single compact controls

### DIFF
--- a/ClientsApp/Views/Client/Index.cshtml
+++ b/ClientsApp/Views/Client/Index.cshtml
@@ -5,10 +5,7 @@
     Layout = "_Layout";
     var currentSortBy = ViewData["SortBy"]?.ToString() ?? "id";
     var currentSortDirection = ViewData["SortDirection"]?.ToString() ?? "asc";
-    var nextIdDirection = currentSortBy == "id" && currentSortDirection == "asc" ? "desc" : "asc";
     var nextNameDirection = currentSortBy == "name" && currentSortDirection == "asc" ? "desc" : "asc";
-    var isDateSortActive = currentSortBy == "id";
-    var dateArrowDirectionClass = isDateSortActive && currentSortDirection == "asc" ? "is-asc" : "is-desc";
 }
 
 <section class="app-page">
@@ -42,17 +39,7 @@
         <section class="app-control-card" aria-label="Сортування клієнтів">
             <h2 class="app-control-card-title">Сортування</h2>
             <div class="app-sort-buttons">
-                <a asp-action="Index" asp-route-searchString="@ViewData["SearchString"]" asp-route-sortBy="id" asp-route-sortDirection="@nextIdDirection" class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
-                    <span class="sort-label-with-icon">
-                        <span>Дата внесення</span>
-                        <span class="sort-arrow @dateArrowDirectionClass" aria-hidden="true">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M12 5v14M12 19l-4-4M12 19l4-4" stroke-linecap="round" stroke-linejoin="round"/>
-                            </svg>
-                        </span>
-                    </span>
-                </a>
-                <a asp-action="Index" asp-route-searchString="@ViewData["SearchString"]" asp-route-sortBy="name" asp-route-sortDirection="@nextNameDirection" class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">Назва (А–Я)</a>
+                <a asp-action="Index" asp-route-searchString="@ViewData["SearchString"]" asp-route-sortBy="name" asp-route-sortDirection="@nextNameDirection" class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">Назва (А-Я)</a>
             </div>
         </section>
     </div>

--- a/ClientsApp/Views/ClientTask/Index.cshtml
+++ b/ClientsApp/Views/ClientTask/Index.cshtml
@@ -53,7 +53,7 @@
                    asp-route-selectedStatus="@(Model.SelectedStatus.HasValue ? ((int)Model.SelectedStatus.Value).ToString() : null)"
                    asp-route-sortOrder="@(Model.SortOrder == "asc" ? "desc" : "asc")"
                    class="btn btn-outline-primary">
-                    Сортувати за датою початку <span class="ms-1">@((Model.SortOrder == "asc") ? "↑" : "↓")</span>
+                    Дата початку <span class="ms-1">@((Model.SortOrder == "asc") ? "↑" : "↓")</span>
                 </a>
             </div>
         </section>

--- a/ClientsApp/Views/Executor/Index.cshtml
+++ b/ClientsApp/Views/Executor/Index.cshtml
@@ -6,7 +6,6 @@
     var currentSortBy = ViewData["SortBy"]?.ToString() ?? "id";
     var currentSortDirection = ViewData["SortDirection"]?.ToString() ?? "desc";
     var nextNameDirection = currentSortBy == "name" && currentSortDirection == "asc" ? "desc" : "asc";
-    var nextIdDirection = currentSortBy == "id" && currentSortDirection == "desc" ? "asc" : "desc";
 }
 
 <section class="app-page">
@@ -56,16 +55,7 @@
                    asp-route-sortBy="name"
                    asp-route-sortDirection="@nextNameDirection"
                    class="btn @(currentSortBy == "name" ? "btn-primary" : "btn-outline-primary")">
-                   ПІБ @(currentSortBy == "name" ? (currentSortDirection == "asc" ? "↑" : "↓") : "")
-                </a>
-                <a asp-action="Index"
-                   asp-route-fullName="@ViewData["FullName"]"
-                   asp-route-hourlyRate="@ViewData["HourlyRate"]"
-                   asp-route-statusFilter="@selectedStatus"
-                   asp-route-sortBy="id"
-                   asp-route-sortDirection="@nextIdDirection"
-                   class="btn @(currentSortBy == "id" ? "btn-primary" : "btn-outline-primary")">
-                   Дата внесення @(currentSortBy == "id" ? (currentSortDirection == "desc" ? "↓" : "↑") : "")
+                   ПІБ (А-Я)
                 </a>
             </div>
         </section>

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -887,7 +887,7 @@ a {
 
 .app-controls-grid--filters-sort {
     grid-template-columns: minmax(0, 5fr) minmax(0, 1fr);
-    align-items: start;
+    align-items: stretch;
 }
 
 .app-section-card,
@@ -960,13 +960,13 @@ a {
 
 .app-sort-buttons {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     gap: 0.75rem;
 }
 
 .app-sort-buttons .btn {
     width: 100%;
-    padding: 0.5rem 0.68rem;
+    padding: 0.5rem 0.8rem;
     font-size: 0.9rem;
 }
 
@@ -996,6 +996,19 @@ a {
 
 .app-sort-buttons--executors .btn {
     padding-inline: 0.65rem;
+}
+
+.app-controls-grid--filters-sort > .app-control-card:nth-child(2) {
+    width: 100%;
+    max-width: 280px;
+    justify-self: end;
+    display: flex;
+    flex-direction: column;
+}
+
+.app-controls-grid--filters-sort > .app-control-card:nth-child(2) .app-sort-buttons {
+    flex: 1;
+    align-content: center;
 }
 
 .app-table-card {
@@ -1077,7 +1090,11 @@ a {
 
 @media (max-width: 991.98px) {
     .app-controls-grid--filters-sort {
-        grid-template-columns: minmax(0, 4fr) minmax(0, 2fr);
+        grid-template-columns: minmax(0, 4fr) minmax(0, 1.3fr);
+    }
+
+    .app-controls-grid--filters-sort > .app-control-card:nth-child(2) {
+        max-width: 240px;
     }
 
     .app-form-page .app-controls-grid {
@@ -1100,6 +1117,11 @@ a {
 @media (max-width: 767.98px) {
     .app-controls-grid--filters-sort {
         grid-template-columns: 1fr;
+    }
+
+    .app-controls-grid--filters-sort > .app-control-card:nth-child(2) {
+        max-width: none;
+        justify-self: stretch;
     }
 
     .app-control-card,


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the Filters+Sorting area by exposing a single, minimal sorting control per page while preserving existing sorting behavior.
- Make the Sorting block a compact utility element that aligns with the Filters area and adapts cleanly across desktop, tablet and mobile breakpoints.

### Description
- Kept sorting functionality but removed extra sort buttons in the clients and executors views and replaced labels with compact variants: `Назва (А-Я)` in `Clients/Index`, `ПІБ (А-Я)` in `Executor/Index`, and `Дата початку` (with existing arrow) in `ClientTask/Index`.
- Preserved existing route parameters and toggle behavior for the tasks sort button by keeping the `asp-route-*` attributes and the ascending/descending indicator markup for `Дата початку`.
- Updated layout/CSS in `wwwroot/css/site.css` to make the sorting block narrow and utility-like by switching `.app-sort-buttons` to a single-column grid, tightening the `app-controls-grid--filters-sort` proportion, and constraining the sorting card with a `max-width` and vertical alignment rules.
- Added responsive adjustments so the Sorting block remains a compact side utility on desktop/tablet and stacks/full-width on mobile without changing filtering, table, or backend logic.

### Testing
- Ran automated repository searches and view inspections (file grep/scan) to confirm each page now contains a single sorting control; the verification passed.
- Performed automated file updates to `Clients/Index`, `Executor/Index`, `ClientTask/Index`, and `wwwroot/css/site.css` and verified the files were modified as expected; the checks passed.
- No unit or integration tests were present or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa01d8eccc832886393cb76d0b2c79)