### PR TITLE
Fix filters/sorting layout and unify reset button

### DIFF
--- a/ClientsApp/Views/ClientTask/Index.cshtml
+++ b/ClientsApp/Views/ClientTask/Index.cshtml
@@ -39,7 +39,7 @@
                     <button type="submit" class="btn btn-primary w-100">Фільтрувати</button>
                 </div>
                 <div class="app-form-field">
-                    <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути усі фільтри</a>
+                    <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути</a>
                 </div>
             </form>
         </section>

--- a/ClientsApp/Views/ExecutorTask/Index.cshtml
+++ b/ClientsApp/Views/ExecutorTask/Index.cshtml
@@ -50,7 +50,7 @@
                 <button type="submit" class="btn btn-primary w-100">Фільтрувати</button>
             </div>
             <div class="app-form-field">
-                <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути усі фільтри</a>
+                <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути</a>
             </div>
         </form>
     </section>

--- a/ClientsApp/Views/Payment/Index.cshtml
+++ b/ClientsApp/Views/Payment/Index.cshtml
@@ -32,7 +32,7 @@
                 <button type="submit" class="btn btn-primary w-100">Фільтрувати</button>
             </div>
             <div class="app-form-field">
-                <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути усі фільтри</a>
+                <a asp-action="Index" class="btn btn-secondary w-100" id="resetFilters">Скинути</a>
             </div>
         </form>
     </section>

--- a/ClientsApp/wwwroot/css/site.css
+++ b/ClientsApp/wwwroot/css/site.css
@@ -452,6 +452,16 @@ a {
     }
 }
 
+
+.app-btn-secondary,
+.app-filters-form .btn.btn-secondary,
+.app-filters-form .btn.btn-outline-secondary {
+    min-height: 42px;
+    border-radius: 10px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+}
+
 @media (max-width: 991.98px) {
     .home-cards {
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -886,8 +896,8 @@ a {
 }
 
 .app-controls-grid--filters-sort {
-    grid-template-columns: minmax(0, 5fr) minmax(0, 1fr);
-    align-items: stretch;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
 }
 
 .app-section-card,
@@ -914,19 +924,23 @@ a {
 }
 
 .app-filters-form {
-    display: grid;
-    grid-template-columns: repeat(12, minmax(0, 1fr));
+    display: flex;
+    flex-wrap: nowrap;
     gap: 0.75rem;
-    align-items: end;
+    align-items: center;
 }
 
 .app-form-field {
-    grid-column: span 3;
     min-width: 0;
+    flex: 1 1 0;
 }
 
 .app-form-field--wide {
-    grid-column: span 6;
+    flex: 1.4 1 0;
+}
+
+.app-filters-form .app-form-field:has(.btn) {
+    flex: 0 0 auto;
 }
 
 .app-filters-form .form-control,
@@ -965,29 +979,26 @@ a {
 }
 
 .app-sort-buttons .btn {
-    width: 100%;
+    width: auto;
+    white-space: nowrap;
     padding: 0.5rem 0.8rem;
     font-size: 0.9rem;
 }
 
-.app-filters-form--executors {
-    row-gap: 0.8rem;
-}
-
 .app-filters-form--executors .app-form-field--name {
-    grid-column: span 5;
+    flex: 1.6 1 0;
 }
 
 .app-filters-form--executors .app-form-field--rate {
-    grid-column: span 4;
+    flex: 1 1 0;
 }
 
 .app-filters-form--executors .app-form-field--status {
-    grid-column: span 3;
+    flex: 1 1 0;
 }
 
 .app-filters-form--executors .app-form-field--action {
-    grid-column: span 3;
+    flex: 0 0 auto;
 }
 
 .app-sort-buttons--executors {
@@ -999,8 +1010,7 @@ a {
 }
 
 .app-controls-grid--filters-sort > .app-control-card:nth-child(2) {
-    width: 100%;
-    max-width: 280px;
+    width: fit-content;
     justify-self: end;
     display: flex;
     flex-direction: column;
@@ -1090,27 +1100,24 @@ a {
 
 @media (max-width: 991.98px) {
     .app-controls-grid--filters-sort {
-        grid-template-columns: minmax(0, 4fr) minmax(0, 1.3fr);
-    }
-
-    .app-controls-grid--filters-sort > .app-control-card:nth-child(2) {
-        max-width: 240px;
+        grid-template-columns: minmax(0, 1fr) auto;
     }
 
     .app-form-page .app-controls-grid {
         grid-template-columns: 1fr;
     }
 
-    .app-form-field,
-    .app-form-field--wide {
-        grid-column: span 6;
+    .app-filters-form {
+        flex-wrap: wrap;
     }
 
+    .app-form-field,
+    .app-form-field--wide,
     .app-filters-form--executors .app-form-field--name,
     .app-filters-form--executors .app-form-field--rate,
     .app-filters-form--executors .app-form-field--status,
     .app-filters-form--executors .app-form-field--action {
-        grid-column: span 6;
+        flex: 1 1 calc(50% - 0.75rem);
     }
 }
 
@@ -1130,21 +1137,22 @@ a {
         padding: 1rem;
     }
 
-    .app-filters-form,
+    .app-filters-form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
     .app-sort-buttons {
         grid-template-columns: 1fr;
     }
 
     .app-form-field,
-    .app-form-field--wide {
-        grid-column: span 1;
-    }
-
+    .app-form-field--wide,
     .app-filters-form--executors .app-form-field--name,
     .app-filters-form--executors .app-form-field--rate,
     .app-filters-form--executors .app-form-field--status,
     .app-filters-form--executors .app-form-field--action {
-        grid-column: span 1;
+        flex: 1 1 100%;
     }
 
     .app-filters-form .btn,


### PR DESCRIPTION
### Motivation
- Filters area should occupy the majority of horizontal space and Sorting should be a compact utility card that fits a single sorting button. 
- Filter controls must appear in a single row on desktop with consistent vertical alignment and button sizing. 
- Reset button text and secondary button visuals must be unified across pages for consistent UX.

### Description
- Adjusted the shared layout so the filters/sorting grid uses `grid-template-columns: minmax(0, 1fr) auto` and aligns controls to the top via the CSS selector `app-controls-grid--filters-sort`. 
- Converted `app-filters-form` from a 12-column grid to a single-row flex layout on desktop (`display: flex; flex-wrap: nowrap;`) with proportional `flex` sizing for `.app-form-field` and `.app-form-field--wide` so controls stay on one row. 
- Made sorting buttons compact by changing `.app-sort-buttons .btn` to `width: auto; white-space: nowrap;` and adjusted the second control card to `width: fit-content` so the Sorting card no longer occupies large width. 
- Added a shared secondary/reset button style via `.app-btn-secondary, .app-filters-form .btn.btn-secondary, .app-filters-form .btn.btn-outline-secondary` to standardize height, radius, padding, and font weight. 
- Ensured action buttons in filter forms do not grow by adding `.app-filters-form .app-form-field:has(.btn) { flex: 0 0 auto; }`. 
- Unified reset button text to `Скинути` in the minimal Razor/HTML changes (no logic changes) for `ClientTask`, `ExecutorTask`, and `Payment` index pages. 
- Files changed: `ClientsApp/wwwroot/css/site.css`, `ClientsApp/Views/ClientTask/Index.cshtml`, `ClientsApp/Views/ExecutorTask/Index.cshtml`, `ClientsApp/Views/Payment/Index.cshtml`.

### Testing
- Attempted `dotnet build` in the environment but it failed because `dotnet` is not available (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa04f498408328994095867a1e7f46)