### PR TITLE
Покращення коментарів у ClientTaskController щодо логіки задач клієнтів

### DIFF
--- a/ClientsApp/Controllers/ClientTaskController.cs
+++ b/ClientsApp/Controllers/ClientTaskController.cs
@@ -11,6 +11,8 @@ using System.Collections.Generic;
 
 namespace ClientsApp.Controllers
 {
+    // Доступ до задач клієнтів вимагає авторизації, щоб сторонні користувачі
+    // не могли переглядати внутрішні дедлайни, статуси й призначених виконавців.
     [Authorize]
     public class ClientTaskController : Controller
     {
@@ -30,8 +32,12 @@ namespace ClientsApp.Controllers
 
         public async Task<IActionResult> Index(int? selectedClientId, int? selectedExecutorId, ClientTaskStatusEnum? selectedStatus, string sortOrder)
         {
+            // Приймаємо тільки два варіанти сортування; будь-яке інше значення
+            // примусово зводимо до "asc", щоб запит до списку задач був передбачуваний.
             var normalizedSortOrder = sortOrder == "desc" ? "desc" : "asc";
             var sortDescending = normalizedSortOrder == "desc";
+            // Завантажуємо задачі з урахуванням вибраних фільтрів (клієнт, виконавець, статус)
+            // та напряму сортування для таблиці задач на головній сторінці.
             var tasks = await _taskService.SearchAsync(selectedClientId, selectedExecutorId, selectedStatus, sortDescending);
 
             var clients = await _clientService.GetAllAsync();
@@ -40,16 +46,21 @@ namespace ClientsApp.Controllers
             var model = new ClientTaskIndexViewModel
             {
                 Tasks = tasks,
+                // Формуємо список клієнтів для фільтра у верхній панелі,
+                // щоб менеджер міг швидко показати задачі тільки конкретного клієнта.
                 Clients = clients.Select(c => new SelectListItem
                 {
                     Value = c.ClientId.ToString(),
                     Text = c.Name
                 }).ToList(),
+                // Формуємо список виконавців для фільтрації задач за відповідальним співробітником.
                 Executors = executors.Select(e => new SelectListItem
                 {
                     Value = e.ExecutorId.ToString(),
                     Text = e.FullName
                 }).ToList(),
+                // Перелік статусів потрібен для відбору задач:
+                // наприклад, показати лише нові або ті, що вже в роботі.
                 Statuses = Enum.GetValues(typeof(ClientTaskStatusEnum))
                     .Cast<ClientTaskStatusEnum>()
                     .Select(s => new SelectListItem
@@ -66,29 +77,41 @@ namespace ClientsApp.Controllers
             return View(model);
         }
 
+        // Створювати нові задачі клієнтів може тільки менеджер, бо саме він
+        // визначає обсяг робіт, строки й виконавців.
         [Authorize(Roles = "Manager")]
         public async Task<IActionResult> Create()
         {
+            // Підготовлюємо дані для форми (клієнти, виконавці, статуси),
+            // щоб на сторінці створення одразу були доступні всі потрібні вибори.
             await PopulateCreateViewBagsAsync();
             return View();
         }
 
         [HttpPost]
+        // Перевіряємо, що форма створення задачі надіслана з нашого сайту,
+        // інакше запит відхиляється як потенційно підроблений.
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Manager")]
         public async Task<IActionResult> Create(ClientTask task, int[] selectedExecutors)
         {
+            // Якщо обов’язкові поля задачі заповнені некоректно,
+            // повертаємо ту саму форму зі збереженими значеннями для виправлення.
             if (!ModelState.IsValid)
             {
                 await PopulateCreateViewBagsAsync(task, selectedExecutors);
                 return View(task);
             }
 
+            // Перевірки доступності виконавців прив’язуємо до дати старту задачі,
+            // оскільки саме з цієї дати люди мають бути реально доступні в роботі.
             var startDate = task.StartDate.Date;
             var selectedExecutorsData = (await _executorService.GetAllAsync())
                 .Where(e => selectedExecutors.Contains(e.ExecutorId))
                 .ToList();
 
+            // Відбираємо лише тих виконавців, які офіційно недоступні на дату початку задачі,
+            // щоб не допустити призначення задачі на період відпустки/відсутності.
             var invalidUnavailableExecutors = selectedExecutorsData
                 .Where(e => e.UnavailableFrom.HasValue
                     && e.UnavailableTo.HasValue
@@ -99,9 +122,13 @@ namespace ClientsApp.Controllers
 
             if (invalidUnavailableExecutors.Count > 0)
             {
+                // Додаємо загальну помилку форми: менеджер бачить перелік недоступних людей
+                // і може одразу змінити команду виконавців для цієї задачі клієнта.
                 ModelState.AddModelError(string.Empty, $"Обрані виконавці недоступні на дату початку: {string.Join(", ", invalidUnavailableExecutors)}.");
             }
 
+            // Окремо блокуємо призначення виконавців, які вже звільнені на дату старту,
+            // щоб у задачі не залишалися неактуальні відповідальні.
             var dismissedExecutors = selectedExecutorsData
                 .Where(e => e.DismissedFrom.HasValue && startDate >= e.DismissedFrom.Value.Date)
                 .Select(e => e.FullName)
@@ -112,12 +139,16 @@ namespace ClientsApp.Controllers
                 ModelState.AddModelError(string.Empty, $"Обрані виконавці звільнені на дату початку: {string.Join(", ", dismissedExecutors)}.");
             }
 
+            // Якщо після перевірок з’явилися помилки, повторно відкриваємо форму,
+            // щоб менеджер відкоригував дату або склад виконавців.
             if (!ModelState.IsValid)
             {
                 await PopulateCreateViewBagsAsync(task, selectedExecutors);
                 return View(task);
             }
 
+            // Перетворюємо вибрані ID у зв’язки задача-виконавець,
+            // щоб зберегти фактичні призначення відповідальних до нової задачі.
             task.ExecutorTasks = selectedExecutors.Select(eid => new ExecutorTask
             {
                 ExecutorId = eid
@@ -125,19 +156,27 @@ namespace ClientsApp.Controllers
 
             await _taskService.AddAsync(task);
 
+            // Після успішного створення повертаємо до загального списку,
+            // де нова задача одразу з’явиться у таблиці задач клієнтів.
             return RedirectToAction(nameof(Index));
         }
 
         [HttpGet]
         public async Task<IActionResult> InProgressByExecutorIds([FromQuery] int[] executorIds)
         {
+            // Якщо ідентифікатори не передані, немає сенсу шукати задачі —
+            // повертаємо порожній JSON для коректної роботи клієнтського запиту.
             if (executorIds == null || executorIds.Length == 0)
             {
                 return Json(Array.Empty<object>());
             }
 
+            // Беремо лише задачі зі статусом InProgress,
+            // щоб показати фактичне поточне навантаження виконавців.
             var allInProgressTasks = await _taskService.SearchAsync(null, null, ClientTaskStatusEnum.InProgress);
 
+            // Фільтруємо задачі за переданими виконавцями та формуємо компактну відповідь:
+            // клієнт, назва задачі, статус і список дотичних виконавців.
             var result = allInProgressTasks
                 .Where(t => t.ExecutorTasks.Any(et => et.ExecutorId.HasValue && executorIds.Contains(et.ExecutorId.Value)))
                 .Select(t => new
@@ -157,10 +196,14 @@ namespace ClientsApp.Controllers
         }
 
 
+        // Редагувати задачі клієнтів може лише менеджер,
+        // оскільки зміна статусу/строків впливає на план робіт команди.
         [Authorize(Roles = "Manager")]
         public async Task<IActionResult> Edit(int id)
         {
             var task = await _taskService.GetByIdAsync(id);
+            // Якщо задачу видалено або ID помилковий, повертаємо 404,
+            // щоб не відкривати порожню форму редагування.
             if (task == null) return NotFound();
 
             var model = new ClientTaskEditViewModel
@@ -172,11 +215,17 @@ namespace ClientsApp.Controllers
                 EndDate = task.EndDate,
                 ClientId = task.ClientId,
                 TaskStatus = task.TaskStatus,
+                // Беремо тільки валідні посилання на виконавців, де є ID,
+                // щоб у формі редагування були позначені реальні призначення задачі.
                 SelectedExecutors = task.ExecutorTasks
                     .Where(et => et.ExecutorId.HasValue)
                     .Select(et => et.ExecutorId!.Value)
                     .ToList(),
+                // SelectList заповнює випадаючий список клієнтів
+                // і одразу встановлює поточного клієнта задачі як вибраний.
                 Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", task.ClientId),
+                // MultiSelectList показує всіх виконавців і підсвічує тих,
+                // хто вже призначений на задачу, щоб менеджер міг змінити склад команди.
                 Executors = new MultiSelectList(await _executorService.GetAllAsync(), "ExecutorId", "FullName", task.ExecutorTasks.Select(et => et.ExecutorId)),
                 Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), task.TaskStatus)
             };
@@ -185,10 +234,14 @@ namespace ClientsApp.Controllers
         }
 
         [HttpPost]
+        // Захищаємо зміну даних задачі від CSRF,
+        // оскільки редагування впливає на реальний робочий план клієнтських задач.
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Manager")]
         public async Task<IActionResult> Edit(ClientTaskEditViewModel model)
         {
+            // Якщо модель не проходить валідацію, повертаємо помилки,
+            // щоб не зберегти задачу з неповними або некоректними даними.
             if (!ModelState.IsValid)
             {
                 var errors = ModelState.Values
@@ -206,10 +259,14 @@ namespace ClientsApp.Controllers
                 EndDate = model.EndDate,
                 ClientId = model.ClientId,
                 TaskStatus = model.TaskStatus,
+                // Формуємо оновлений перелік призначень виконавців:
+                // після збереження саме цей склад відповідатиме за задачу.
                 ExecutorTasks = model.SelectedExecutors.Select(eid => new ExecutorTask { ExecutorId = eid }).ToList()
             };
 
             await _taskService.UpdateAsync(task);
+            // Після оновлення задачі повертаємося до списку,
+            // щоб менеджер одразу бачив актуальні статуси й призначення.
             return RedirectToAction(nameof(Index));
         }
 
@@ -217,16 +274,22 @@ namespace ClientsApp.Controllers
         public async Task<IActionResult> Delete(int id)
         {
             var task = await _taskService.GetByIdAsync(id);
+            // Якщо задачу за цим ID не знайдено, показуємо 404
+            // замість сторінки підтвердження видалення неіснуючого запису.
             if (task == null) return NotFound();
             return View(task);
         }
 
         [HttpPost, ActionName("Delete")]
+        // Підтвердження видалення теж захищене anti-forgery токеном,
+        // щоб сторонній сайт не міг видалити задачу від імені менеджера.
         [ValidateAntiForgeryToken]
         [Authorize(Roles = "Manager")]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             await _taskService.DeleteAsync(id);
+            // Після видалення задачі повертаємо до переліку,
+            // де запис уже не відображатиметься у списку задач клієнтів.
             return RedirectToAction(nameof(Index));
         }
 
@@ -234,12 +297,20 @@ namespace ClientsApp.Controllers
         {
             var today = DateTime.Today;
 
+            // ViewBag.Clients використовується у формі створення:
+            // менеджер обирає, для якого саме клієнта заводиться задача.
             ViewBag.Clients = new SelectList(await _clientService.GetAllAsync(), "ClientId", "Name", task?.ClientId);
+            // У список виконавців не додаємо звільнених станом на сьогодні
+            // і сортуємо за ПІБ, щоб менеджеру було простіше знайти потрібну людину.
             ViewBag.Executors = (await _executorService.GetAllAsync())
                 .Where(e => !e.DismissedFrom.HasValue || e.DismissedFrom.Value.Date >= today)
                 .OrderBy(e => e.FullName)
                 .ToList();
+            // Зберігаємо попередній вибір виконавців після помилки валідації,
+            // щоб менеджеру не довелося повторно відмічати їх у формі.
             ViewBag.SelectedExecutors = new HashSet<int>(selectedExecutors ?? Array.Empty<int>());
+            // Передаємо перелік можливих статусів задачі (наприклад New/InProgress/Done)
+            // для вибору поточного стану під час створення або повторного показу форми.
             ViewBag.Statuses = new SelectList(Enum.GetValues(typeof(ClientTaskStatusEnum)), task?.TaskStatus);
         }
     }


### PR DESCRIPTION
### Motivation
- Зробити коментарі в `ClientTaskController` предметними і зрозумілими для розробників, які працюватимуть із фільтрацією, призначенням виконавців і CRUD-операціями над задачами клієнтів.
- Пояснити, чому застосовані перевірки доступності виконавців, захист від CSRF і `Authorize`-обмеження та який реальний ефект цих дій на дані задач.

### Description
- Додано конкретні коментарі на рівні контролера й дій, зокрема пояснення до `Authorize` про закриття доступу до внутрішніх дедлайнів, статусів і призначень виконавців.
- У `Index` уточнено нормалізацію `sortOrder` і те, що запит у `SearchAsync` враховує фільтри `selectedClientId`, `selectedExecutorId`, `selectedStatus` і напрям сортування для таблиці задач.
- Для `Create`/`Edit`/`Delete` додано пояснення про `ValidateAntiForgeryToken`, обробку `ModelState` (повторне заповнення `ViewBag` при помилках), перевірки `UnavailableFrom/UnavailableTo` і `DismissedFrom` для вибраних виконавців, і про перетворення `selectedExecutors` у `ExecutorTasks` перед збереженням.
- У `InProgressByExecutorIds` і `PopulateCreateViewBagsAsync` додано коментарі про поводження з порожніми запитами, формування компактного JSON-відповіді, виключення звільнених виконавців та наповнення `ViewBag`/`SelectList`/`MultiSelectList` для форм і фільтрів.

### Testing
- Жодних автоматизованих тестів для цього патчу не запускалося; зміни стосуються лише коментарів і не змінюють виконувальну логіку коду.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bec5aec4832880c003a312821c57)