### PR TITLE
Clarify authorization and account-flow comments in AccountController

### DIFF
--- a/ClientsApp/Controllers/AccountController.cs
+++ b/ClientsApp/Controllers/AccountController.cs
@@ -7,12 +7,24 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ClientsApp.Controllers
 {
+    // Цей контролер відповідає за облікові записи працівників:
+    // вхід, вихід, створення акаунтів та зміну власних облікових даних менеджера.
     public class AccountController : Controller
     {
+        // Через форму реєстрації менеджер може створити тільки ці ролі,
+        // щоб випадково не видати привілеї Manager або іншу службову роль.
         private static readonly string[] AllowedRoles = ["Accountant", "Executor"];
 
+        // UserManager працює з користувачем у сховищі Identity:
+        // створює акаунт, змінює email/логін, змінює пароль, шукає за email.
         private readonly UserManager<ApplicationUser> _userManager;
+
+        // SignInManager відповідає за вхід/вихід і cookie авторизації:
+        // перевіряє пароль та створює/оновлює сесію в браузері.
         private readonly SignInManager<ApplicationUser> _signInManager;
+
+        // Контекст потрібен для перевірки звʼязку з таблицею Executors
+        // під час створення користувача з роллю Executor.
         private readonly ApplicationDbContext _context;
 
         public AccountController(
@@ -25,31 +37,43 @@ namespace ClientsApp.Controllers
             _context = context;
         }
 
+        // Нові облікові записи співробітників у системі створює тільки менеджер.
         [Authorize(Roles = "Manager")]
         [HttpGet]
         public IActionResult Register()
         {
+            // Передаємо у форму лише дозволені ролі,
+            // щоб список ролей у UI не розходився з серверною валідацією.
             ViewBag.Roles = AllowedRoles;
             return View(new RegisterViewModel());
         }
 
+        // Нові облікові записи співробітників у системі створює тільки менеджер.
         [Authorize(Roles = "Manager")]
         [HttpPost]
+        // Перевіряє, що форму реєстрації відправлено з нашого сайту,
+        // а не підробленим запитом із зовнішньої сторінки.
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Register(RegisterViewModel model)
         {
             ViewBag.Roles = AllowedRoles;
 
+            // Дублюємо перевірку ролі на сервері, бо значення role можна підмінити в HTTP-запиті,
+            // навіть якщо в інтерфейсі користувач бачить тільки AllowedRoles.
             if (!AllowedRoles.Contains(model.Role))
             {
                 ModelState.AddModelError(nameof(model.Role), "Оберіть коректну роль.");
             }
 
+            // Якщо валідація моделі не пройшла (email, пароль, роль),
+            // повертаємо форму з конкретними помилками із ModelState.
             if (!ModelState.IsValid)
             {
                 return View(model);
             }
 
+            // Email використовується і як логін UserName,
+            // тому входити в систему користувач буде саме через email.
             var user = new ApplicationUser
             {
                 UserName = model.Email,
@@ -58,6 +82,8 @@ namespace ClientsApp.Controllers
 
             if (model.Role == "Executor")
             {
+                // Для ролі Executor шукаємо існуючого виконавця з тим самим email:
+                // це гарантує, що акаунт привʼязується до реального запису співробітника.
                 var executor = await _context.Executors.FirstOrDefaultAsync(e => e.Email == model.Email);
                 if (executor == null)
                 {
@@ -65,13 +91,18 @@ namespace ClientsApp.Controllers
                     return View(model);
                 }
 
+                // Зберігаємо ExecutorId у користувачі,
+                // щоб система могла повʼязувати вхід у акаунт з задачами та даними конкретного виконавця.
                 user.ExecutorId = executor.ExecutorId;
             }
 
-// Створюємо нового користувача в таблицях AspNetUsers/AspNetUserRoles.
+            // CreateAsync створює запис користувача в Identity та хешує пароль,
+            // тому пароль не зберігається у відкритому вигляді.
             var result = await _userManager.CreateAsync(user, model.Password);
             if (!result.Succeeded)
             {
+                // Помилки Identity (слабкий пароль, дубль email тощо)
+                // додаємо в ModelState, щоб менеджер бачив причину відмови у формі.
                 foreach (var error in result.Errors)
                 {
                     ModelState.AddModelError(string.Empty, error.Description);
@@ -80,12 +111,16 @@ namespace ClientsApp.Controllers
                 return View(model);
             }
 
-// Призначаємо роль, яка визначатиме доступ до захищених дій контролерів.
+            // Призначаємо роль одразу після створення,
+            // інакше новий користувач не отримає доступ до потрібних розділів системи.
             await _userManager.AddToRoleAsync(user, model.Role);
 
+            // Після створення акаунта повертаємо менеджера на головну,
+            // а не входимо під новим користувачем у поточній сесії.
             return RedirectToAction("Index", "Home");
         }
 
+        // Сторінка редагування облікових даних доступна тільки менеджеру.
         [Authorize(Roles = "Manager")]
         [HttpGet]
         public async Task<IActionResult> Profile()
@@ -93,6 +128,8 @@ namespace ClientsApp.Controllers
             var user = await _userManager.GetUserAsync(User);
             if (user is null)
             {
+                // Якщо cookie є, але користувача вже видалили з бази,
+                // перенаправляємо на повторний вхід.
                 return RedirectToAction(nameof(Login));
             }
 
@@ -110,6 +147,7 @@ namespace ClientsApp.Controllers
 
         [Authorize(Roles = "Manager")]
         [HttpPost]
+        // Блокує підроблену відправку форми зміни email з іншого сайту.
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> UpdateEmail([Bind(Prefix = "UpdateEmail")] UpdateEmailViewModel model)
         {
@@ -119,6 +157,8 @@ namespace ClientsApp.Controllers
                 return RedirectToAction(nameof(Login));
             }
 
+            // Якщо новий email не проходить валідацію, показуємо цю ж сторінку профілю
+            // та повертаємо введене значення, щоб менеджер міг виправити помилку.
             if (!ModelState.IsValid)
             {
                 return View("Profile", new ManageAccountViewModel
@@ -128,6 +168,8 @@ namespace ClientsApp.Controllers
                 });
             }
 
+            // Не дозволяємо зайняти email іншого користувача,
+            // бо email в цій системі одночасно є ідентифікатором входу.
             var emailInUse = await _userManager.FindByEmailAsync(model.NewEmail);
             if (emailInUse is not null && emailInUse.Id != user.Id)
             {
@@ -139,6 +181,7 @@ namespace ClientsApp.Controllers
                 });
             }
 
+            // Оновлюємо email у профілі Identity.
             var setEmailResult = await _userManager.SetEmailAsync(user, model.NewEmail);
             if (!setEmailResult.Succeeded)
             {
@@ -154,6 +197,8 @@ namespace ClientsApp.Controllers
                 });
             }
 
+            // UserName також має збігатися з email,
+            // щоб вхід працював передбачувано через одне й те саме значення.
             var setUserNameResult = await _userManager.SetUserNameAsync(user, model.NewEmail);
             if (!setUserNameResult.Succeeded)
             {
@@ -169,14 +214,23 @@ namespace ClientsApp.Controllers
                 });
             }
 
+            // Оновлюємо cookie поточної сесії, щоб у claims ідентичності
+            // одразу відобразився новий email без примусового повторного входу.
             await _signInManager.RefreshSignInAsync(user);
+
+            // TempData зберігає коротке повідомлення між редиректами,
+            // тому текст успіху буде показаний вже після переходу на Profile.
             TempData["SuccessMessage"] = "Email успішно змінено.";
 
+            // RedirectToAction розриває повторну відправку форми при оновленні сторінки
+            // і відкриває чистий GET профілю з новими даними.
             return RedirectToAction(nameof(Profile));
         }
 
         [Authorize(Roles = "Manager")]
         [HttpPost]
+        // Перевіряє anti-forgery токен для форми зміни пароля,
+        // щоб пароль не можна було змінити через сторонній сайт від імені менеджера.
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> ChangePassword([Bind(Prefix = "ChangePassword")] ChangePasswordViewModel model)
         {
@@ -198,6 +252,8 @@ namespace ClientsApp.Controllers
                 });
             }
 
+            // ChangePasswordAsync вимагає поточний пароль,
+            // тому стороння людина з відкритою сесією не зможе тихо змінити пароль без знання старого.
             var changePasswordResult = await _userManager.ChangePasswordAsync(user, model.CurrentPassword, model.NewPassword);
             if (!changePasswordResult.Succeeded)
             {
@@ -216,22 +272,29 @@ namespace ClientsApp.Controllers
                 });
             }
 
+            // Після зміни пароля оновлюємо cookie входу,
+            // щоб поточна сесія залишалась валідною без повторного логіну.
             await _signInManager.RefreshSignInAsync(user);
             TempData["SuccessMessage"] = "Пароль успішно змінено.";
 
             return RedirectToAction(nameof(Profile));
         }
 
+        // Сторінка входу доступна без авторизації,
+        // інакше неавторизований користувач не зможе потрапити у систему.
         [AllowAnonymous]
         [HttpGet]
         public IActionResult Login(string? returnUrl = null)
         {
+            // Зберігаємо адресу, куди треба повернути користувача після входу,
+            // якщо він спочатку відкрив захищену сторінку.
             ViewData["ReturnUrl"] = returnUrl;
             return View(new LoginViewModel());
         }
 
         [AllowAnonymous]
         [HttpPost]
+        // Перевіряє, що форму входу надіслав саме наш сайт.
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Login(LoginViewModel model, string? returnUrl = null)
         {
@@ -241,10 +304,13 @@ namespace ClientsApp.Controllers
                 return View(model);
             }
 
-// Перевіряємо облікові дані через Identity і при успіху створюємо cookie-сесію.
+            // PasswordSignInAsync перевіряє email і пароль через Identity,
+            // а у випадку успіху створює cookie авторизованого користувача.
             var result = await _signInManager.PasswordSignInAsync(model.Email, model.Password, model.RememberMe, lockoutOnFailure: false);
             if (result.Succeeded)
             {
+                // Якщо перед входом користувач запитував захищений URL,
+                // RedirectToLocal поверне його на ту адресу замість головної.
                 return RedirectToLocal(returnUrl);
             }
 
@@ -254,9 +320,12 @@ namespace ClientsApp.Controllers
 
         [Authorize]
         [HttpPost]
+        // Підтверджує, що запит на вихід ініційовано з нашої сторінки.
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Logout()
         {
+            // SignOutAsync очищає cookie авторизації,
+            // щоб цей браузер більше не вважався залогіненим.
             await _signInManager.SignOutAsync();
             return RedirectToAction("Index", "Home");
         }
@@ -270,11 +339,15 @@ namespace ClientsApp.Controllers
 
         private IActionResult RedirectToLocal(string? returnUrl)
         {
+            // Дозволяємо редирект тільки на локальну адресу сайту,
+            // щоб запобігти open redirect на зовнішні домени.
             if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
             {
                 return Redirect(returnUrl);
             }
 
+            // Якщо returnUrl порожній або небезпечний,
+            // відправляємо користувача на стандартну домашню сторінку.
             return RedirectToAction("Index", "Home");
         }
     }


### PR DESCRIPTION
### Motivation
- Зробити коментарі в `ClientsApp/Controllers/AccountController.cs` конкретнішими, щоб пояснювали, навіщо виконуються перевірки ролей, email, прив’язка `ExecutorId`, використання `UserManager` / `SignInManager`, `RefreshSignInAsync`, `ValidateAntiForgeryToken`, та логіка редиректів (`returnUrl`, `Url.IsLocalUrl`, `RedirectToAction`).
- Покращити читабельність коду для підтримки й ревʼю, не змінюючи жодної виконуваної логіки. 

### Description
- Оновлено коментарі в `AccountController` поруч із `Register`, `Login`, `Logout`, `Profile`, `UpdateEmail`, `ChangePassword`, та `RedirectToLocal`, щоб пояснити конкретну мотивацію кожної перевірки і кожного виклику API Identity.  
- Додано пояснення ролі `AllowedRoles` і чому менеджер може створювати лише `Accountant` і `Executor`.  
- Пояснено перевірку існування `Executor` за `Email` і привʼязку `ExecutorId`, перевірку унікальності `Email` через `UserManager`, і чому `UserName` синхронізується з `Email`.  
- Роз’яснено безпекову роль `ValidateAntiForgeryToken`, механіку `PasswordSignInAsync`, `ChangePasswordAsync`, та причину виклику `RefreshSignInAsync` після оновлення email/пароля; також описано використання `TempData` і PRG-патерну через `RedirectToAction` і перевірку `returnUrl` через `Url.IsLocalUrl`.

### Testing
- Перевірено різницю файлу та вміст `ClientsApp/Controllers/AccountController.cs` шляхом огляду змін (diff/content inspection) і підтверджено, що змін лише коментарі.  
- Жодних автоматизованих рантайм-тестів не було потрібно, бо кодова поведінка не змінювалася; статичні огляди файлу пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c054e47883289d48ba8ba1bd140b)