### PR TITLE
Покращені коментарі в HomeController для стартової сторінки та обробки помилок

### DIFF
--- a/ClientsApp/Controllers/HomeController.cs
+++ b/ClientsApp/Controllers/HomeController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace ClientsApp.Controllers
 {
+    // Контролер стартового блоку: відкриває головну сторінку, сторінку приватності та екран помилки.
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
@@ -13,19 +14,30 @@ namespace ClientsApp.Controllers
             _logger = logger;
         }
 
+        // Показує головну (стартову) сторінку застосунку, яку користувач бачить після відкриття сайту.
+        // Обмежень доступу немає: атрибути Authorize відсутні, тому сторінка доступна всім відвідувачам.
         public IActionResult Index()
         {
             return View();
         }
 
+        // Відкриває сторінку Privacy з політикою конфіденційності для всіх користувачів, включно з неавторизованими.
         public IActionResult Privacy()
         {
             return View();
         }
 
+        // Екран помилки не кешуємо,
+        // щоб після повторної спроби користувач не бачив застарілий стан аварійної сторінки.
+        // Duration = 0 вимикає збереження на час, Location = None забороняє кеші браузера/проксі,
+        // NoStore = true забороняє взагалі записувати відповідь у кеш.
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
         {
+            // RequestId передаємо у модель помилки, щоб користувач або підтримка могли звірити
+            // конкретний збій із записом у логах HomeController.
+            // Якщо Activity.Current недоступний, беремо HttpContext.TraceIdentifier
+            // як стабільний ідентифікатор поточного HTTP-запиту.
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
         }
     }


### PR DESCRIPTION
### Motivation
- Уточнити в коді, що саме показує головна сторінка і сторінка приватності, кому доступні ці екранні дії та чітко пояснити логіку формування ідентифікатора помилки і причину відключення кешування для екрану помилок.

### Description
- Додано конкретні коментарі до класу `HomeController`, які вказують що контролер відповідає за стартовий екран, сторінку приватності та екран помилок, і що доступ до Index/Privacy відкритий (відсутній `Authorize`).
- Коментарі біля `Index` та `Privacy` пояснюють, що бачить користувач на цих сторінках і що вони доступні всім відвідувачам, включно з неавторизованими.
- Розширено коментар біля атрибута `ResponseCache` і методу `Error`, щоб пояснити значення `Duration = 0`, `Location = ResponseCacheLocation.None` і `NoStore = true`, а також чому сторінка помилки не має кешуватися і як `RequestId` будується через `Activity.Current?.Id` з fallback на `HttpContext.TraceIdentifier` для ідентифікації помилок у логах.

### Testing
- Жодних автоматичних тестів не запускалось; змінено лише коментарі в `ClientsApp/Controllers/HomeController.cs` і логікою виконання програми не торкнутося.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c380c5148328950f815d086af95e)